### PR TITLE
Add save copy of uploaded audio file to local recordings storage

### DIFF
--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/local/file/RecordingFileHandler.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/local/file/RecordingFileHandler.kt
@@ -2,9 +2,13 @@ package edu.cit.audioscholar.data.local.file
 
 import android.content.Context
 import android.media.MediaRecorder
+import android.net.Uri
+import android.provider.OpenableColumns
 import android.util.Log
+import android.webkit.MimeTypeMap
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -14,7 +18,6 @@ import javax.inject.Inject
 private const val RECORDINGS_DIRECTORY_NAME = "Recordings"
 private const val FILENAME_DATE_FORMAT = "yyyy-MM-dd_HH-mm-ss"
 private const val FILENAME_PREFIX = "Recording_"
-private const val FILENAME_EXTENSION = ".m4a"
 
 private const val AUDIO_SOURCE = MediaRecorder.AudioSource.MIC
 private const val OUTPUT_FORMAT = MediaRecorder.OutputFormat.MPEG_4
@@ -29,7 +32,7 @@ class RecordingFileHandler @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
 
-    fun setupMediaRecorderOutputFile(mediaRecorder: MediaRecorder): Result<File> {
+    private fun getRecordingsDirectory(): Result<File> {
         return try {
             val baseDir = context.getExternalFilesDir(null)
             if (baseDir == null) {
@@ -53,12 +56,83 @@ class RecordingFileHandler @Inject constructor(
                 Log.e(TAG, "Recordings path exists but is not a directory: ${recordingsDir.absolutePath}")
                 return Result.failure(IOException("Path exists but is not a directory: ${recordingsDir.absolutePath}"))
             }
+            Result.success(recordingsDir)
+        } catch (e: SecurityException) {
+            Log.e(TAG, "SecurityException accessing recordings directory", e)
+            Result.failure(e)
+        } catch (e: Exception) {
+            Log.e(TAG, "Unexpected error accessing recordings directory", e)
+            Result.failure(e)
+        }
+    }
 
+    private fun getFileExtensionFromUri(uri: Uri): String {
+        val mimeType = context.contentResolver.getType(uri)
+        val extension = if (mimeType != null) {
+            MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
+        } else {
+            MimeTypeMap.getFileExtensionFromUrl(uri.toString())
+        }
+        return if (!extension.isNullOrBlank()) ".$extension" else ".audio"
+    }
 
+    fun copyUriToLocalRecordings(sourceUri: Uri): Result<File> {
+        val recordingsDirResult = getRecordingsDirectory()
+        if (recordingsDirResult.isFailure) {
+            return Result.failure(recordingsDirResult.exceptionOrNull() ?: IOException("Failed to get recordings directory"))
+        }
+        val recordingsDir = recordingsDirResult.getOrThrow()
+
+        return try {
             val timestamp = SimpleDateFormat(FILENAME_DATE_FORMAT, Locale.US).format(Date())
-            val filename = "$FILENAME_PREFIX$timestamp$FILENAME_EXTENSION"
+            val extension = getFileExtensionFromUri(sourceUri)
+            val filename = "$FILENAME_PREFIX$timestamp$extension"
+            val destinationFile = File(recordingsDir, filename)
+
+            Log.d(TAG, "Attempting to copy Uri $sourceUri to local file ${destinationFile.absolutePath}")
+
+            context.contentResolver.openInputStream(sourceUri)?.use { inputStream ->
+                FileOutputStream(destinationFile).use { outputStream ->
+                    val buffer = ByteArray(4 * 1024)
+                    var read: Int
+                    while (inputStream.read(buffer).also { read = it } != -1) {
+                        outputStream.write(buffer, 0, read)
+                    }
+                    outputStream.flush()
+                }
+            } ?: run {
+                Log.e(TAG, "Failed to open input stream for Uri: $sourceUri")
+                return Result.failure(IOException("Could not open input stream for the selected file."))
+            }
+
+            Log.i(TAG, "Successfully copied uploaded file to local storage: ${destinationFile.absolutePath}")
+            Result.success(destinationFile)
+
+        } catch (e: IOException) {
+            Log.e(TAG, "IOException during file copy from Uri $sourceUri", e)
+            Result.failure(e)
+        } catch (e: SecurityException) {
+            Log.e(TAG, "SecurityException during file copy from Uri $sourceUri", e)
+            Result.failure(e)
+        } catch (e: Exception) {
+            Log.e(TAG, "Unexpected error during file copy from Uri $sourceUri", e)
+            Result.failure(e)
+        }
+    }
+
+
+    fun setupMediaRecorderOutputFile(mediaRecorder: MediaRecorder): Result<File> {
+        val recordingsDirResult = getRecordingsDirectory()
+        if (recordingsDirResult.isFailure) {
+            return Result.failure(recordingsDirResult.exceptionOrNull() ?: IOException("Failed to get recordings directory"))
+        }
+        val recordingsDir = recordingsDirResult.getOrThrow()
+
+        return try {
+            val timestamp = SimpleDateFormat(FILENAME_DATE_FORMAT, Locale.US).format(Date())
+            val filename = "$FILENAME_PREFIX$timestamp.m4a"
             val outputFile = File(recordingsDir, filename)
-            Log.d(TAG, "Generated output file path: ${outputFile.absolutePath}")
+            Log.d(TAG, "Generated output file path for recording: ${outputFile.absolutePath}")
 
             mediaRecorder.setAudioSource(AUDIO_SOURCE)
             mediaRecorder.setOutputFormat(OUTPUT_FORMAT)
@@ -75,7 +149,7 @@ class RecordingFileHandler @Inject constructor(
             Log.e(TAG, "IOException during MediaRecorder setup", e)
             Result.failure(e)
         } catch (e: SecurityException) {
-            Log.e(TAG, "SecurityException during directory creation or file access", e)
+            Log.e(TAG, "SecurityException during MediaRecorder setup", e)
             Result.failure(e)
         } catch (e: IllegalStateException) {
             Log.e(TAG, "IllegalStateException during MediaRecorder configuration", e)

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/di/NetworkModule.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/di/NetworkModule.kt
@@ -34,9 +34,9 @@ object NetworkModule {
     fun provideOkHttpClient(loggingInterceptor: HttpLoggingInterceptor): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(loggingInterceptor)
-            .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
-            .readTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
-            .writeTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+            .connectTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+            .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+            .writeTimeout(90, java.util.concurrent.TimeUnit.SECONDS)
             .build()
     }
 
@@ -66,8 +66,9 @@ object NetworkModule {
     @Singleton
     fun provideAudioRepository(
         apiService: ApiService,
-        application: Application
+        application: Application,
+        gson: Gson
     ): AudioRepository {
-        return AudioRepositoryImpl(apiService, application)
+        return AudioRepositoryImpl(apiService, application, gson)
     }
 }

--- a/frontend_mobile/AudioScholar/app/src/main/res/values/strings.xml
+++ b/frontend_mobile/AudioScholar/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="upload_error_generic_prefix">Error: %1$s</string>
     <string name="upload_error_failed">Error: Upload failed.</string>
     <string name="upload_info_starting">Starting upload…</string>
+    <string name="upload_info_progress">Uploading: %1$d%%</string>
     <string name="button_back_to_recording">Back to Recording</string>
 
     <string name="nav_record">Record</string>


### PR DESCRIPTION
This pull request adds a feature to save a copy of the uploaded audio file to the local recordings storage for Library Access. It includes changes to the UI strings, network module, and recording file handler.