### PR TITLE
Fetch and Display Audio Metadata List from Backend to Mobile

### DIFF
--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/service/ApiService.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/service/ApiService.kt
@@ -4,6 +4,7 @@ import edu.cit.audioscholar.data.remote.dto.AudioMetadataDto
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.Response
+import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
@@ -17,5 +18,8 @@ interface ApiService {
         @Part("title") title: RequestBody?,
         @Part("description") description: RequestBody?
     ): Response<AudioMetadataDto>
+
+    @GET("/api/audio/metadata")
+    suspend fun getAudioMetadataList(): Response<List<AudioMetadataDto>>
 
 }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/AudioRepository.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/AudioRepository.kt
@@ -2,6 +2,7 @@ package edu.cit.audioscholar.domain.repository
 
 import android.net.Uri
 import edu.cit.audioscholar.data.local.model.RecordingMetadata
+import edu.cit.audioscholar.data.remote.dto.AudioMetadataDto
 import kotlinx.coroutines.flow.Flow
 
 sealed class UploadResult {
@@ -21,4 +22,6 @@ interface AudioRepository {
     fun getLocalRecordings(): Flow<List<RecordingMetadata>>
 
     suspend fun deleteLocalRecording(metadata: RecordingMetadata): Boolean
+
+    fun getCloudRecordings(): Flow<Result<List<AudioMetadataDto>>>
 }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/AudioRepositoryImpl.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/AudioRepositoryImpl.kt
@@ -369,4 +369,23 @@ class AudioRepositoryImpl @Inject constructor(
 
         return@withContext audioDeleted
     }
+
+    override fun getCloudRecordings(): Flow<Result<List<AudioMetadataDto>>> = flow {
+        try {
+            Log.d(TAG_REPO, "Fetching cloud recordings metadata from API...")
+            val response = apiService.getAudioMetadataList()
+            if (response.isSuccessful) {
+                val metadataList = response.body() ?: emptyList()
+                Log.i(TAG_REPO, "Successfully fetched ${metadataList.size} cloud recordings metadata.")
+                emit(Result.success(metadataList))
+            } else {
+                val errorBody = response.errorBody()?.string() ?: "Unknown server error"
+                Log.e(TAG_REPO, "Failed to fetch cloud recordings: ${response.code()} - $errorBody")
+                emit(Result.failure(IOException("API Error ${response.code()}: $errorBody")))
+            }
+        } catch (e: Exception) {
+            Log.e(TAG_REPO, "Exception fetching cloud recordings: ${e.message}", e)
+            emit(Result.failure(e))
+        }
+    }.flowOn(Dispatchers.IO)
 }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/library/LocalRecordingsViewModel.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/library/LocalRecordingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import edu.cit.audioscholar.data.local.model.RecordingMetadata
+import edu.cit.audioscholar.data.remote.dto.AudioMetadataDto
 import edu.cit.audioscholar.domain.repository.AudioRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -14,9 +15,11 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-data class LocalRecordingsUiState(
-    val isLoading: Boolean = false,
-    val recordings: List<RecordingMetadata> = emptyList(),
+data class LibraryUiState(
+    val isLoadingLocal: Boolean = false,
+    val isLoadingCloud: Boolean = false,
+    val localRecordings: List<RecordingMetadata> = emptyList(),
+    val cloudRecordings: List<AudioMetadataDto> = emptyList(),
     val error: String? = null,
     val recordingToDelete: RecordingMetadata? = null
 )
@@ -26,37 +29,77 @@ class LocalRecordingsViewModel @Inject constructor(
     private val audioRepository: AudioRepository
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(LocalRecordingsUiState())
-    val uiState: StateFlow<LocalRecordingsUiState> = _uiState.asStateFlow()
+    private val _uiState = MutableStateFlow(LibraryUiState())
+    val uiState: StateFlow<LibraryUiState> = _uiState.asStateFlow()
 
     init {
-        loadRecordings()
+        loadAllRecordings()
     }
 
-    fun loadRecordings() {
+    fun loadAllRecordings() {
+        loadLocalRecordings()
+        loadCloudRecordings()
+    }
+
+    private fun loadLocalRecordings() {
         viewModelScope.launch {
             audioRepository.getLocalRecordings()
                 .onStart {
-                    _uiState.update { it.copy(isLoading = it.recordings.isEmpty(), error = null) }
+                    _uiState.update { it.copy(isLoadingLocal = true, error = null) }
                 }
                 .catch { throwable ->
                     _uiState.update {
                         it.copy(
-                            isLoading = false,
-                            error = "Failed to load recordings: ${throwable.message}"
+                            isLoadingLocal = false,
+                            error = it.error ?: "Failed to load local recordings: ${throwable.message}"
                         )
                     }
                 }
                 .collect { recordingsList ->
                     _uiState.update {
                         it.copy(
-                            isLoading = false,
-                            recordings = recordingsList
+                            isLoadingLocal = false,
+                            localRecordings = recordingsList
                         )
                     }
                 }
         }
     }
+
+    private fun loadCloudRecordings() {
+        viewModelScope.launch {
+            audioRepository.getCloudRecordings()
+                .onStart {
+                    _uiState.update { it.copy(isLoadingCloud = true, error = null) }
+                }
+                .catch { throwable ->
+                    _uiState.update {
+                        it.copy(
+                            isLoadingCloud = false,
+                            error = it.error ?: "Failed to load cloud recordings: ${throwable.message}"
+                        )
+                    }
+                }
+                .collect { result ->
+                    result.onSuccess { metadataList ->
+                        _uiState.update {
+                            it.copy(
+                                isLoadingCloud = false,
+                                cloudRecordings = metadataList.sortedByDescending { dto -> dto.uploadTimestamp?.seconds }
+                            )
+                        }
+                    }.onFailure { throwable ->
+                        _uiState.update {
+                            it.copy(
+                                isLoadingCloud = false,
+                                error = it.error ?: "Failed to load cloud recordings: ${throwable.message}"
+                            )
+                        }
+                    }
+                }
+        }
+    }
+
 
     fun requestDeleteConfirmation(metadata: RecordingMetadata) {
         _uiState.update { it.copy(recordingToDelete = metadata) }
@@ -68,16 +111,16 @@ class LocalRecordingsViewModel @Inject constructor(
 
     fun confirmDelete() {
         val recording = _uiState.value.recordingToDelete ?: return
-        _uiState.update { it.copy(recordingToDelete = null, isLoading = true) }
+        _uiState.update { it.copy(recordingToDelete = null, isLoadingLocal = true) }
 
         viewModelScope.launch {
             val success = audioRepository.deleteLocalRecording(recording)
             if (success) {
-                loadRecordings()
+                loadLocalRecordings()
             } else {
                 _uiState.update {
                     it.copy(
-                        isLoading = false,
+                        isLoadingLocal = false,
                         error = "Failed to delete '${recording.fileName}'"
                     )
                 }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/main/MainActivity.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/main/MainActivity.kt
@@ -28,7 +28,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import edu.cit.audioscholar.R
 import edu.cit.audioscholar.service.NAVIGATE_TO_EXTRA
 import edu.cit.audioscholar.service.UPLOAD_SCREEN_VALUE
-import edu.cit.audioscholar.ui.library.LocalRecordingsListScreen
+import edu.cit.audioscholar.ui.library.LibraryScreen
 import edu.cit.audioscholar.ui.recording.RecordingScreen
 import edu.cit.audioscholar.ui.theme.AudioScholarTheme
 import edu.cit.audioscholar.ui.upload.UploadScreen
@@ -151,7 +151,7 @@ fun MainAppScreen(navController: NavHostController) {
                 RecordingScreen(navController = navController)
             }
             composable(Screen.Library.route) {
-                LocalRecordingsListScreen()
+                LibraryScreen()
             }
             composable(Screen.Upload.route) {
                 UploadScreen(

--- a/frontend_mobile/AudioScholar/app/src/main/res/values/strings.xml
+++ b/frontend_mobile/AudioScholar/app/src/main/res/values/strings.xml
@@ -50,6 +50,11 @@
     <string name="nav_upload">Upload</string>
     <string name="nav_settings">Settings</string>
 
+    <string name="library_tab_local">Local</string>
+    <string name="library_tab_cloud">Cloud</string>
+    <string name="library_empty_state_local">No local recordings found.\nStart recording from the Record tab!</string>
+    <string name="library_empty_state_cloud">No recordings uploaded yet.\nUpload recordings from the Upload tab or record and save locally first.</string>
+    <string name="cd_cloud_recording_indicator">Cloud recording</string>
     <string name="library_empty_state">No recordings found.\nTap the Record tab to make one!</string>
     <string name="cd_delete_recording">Delete recording %1$s</string>
     <string name="dialog_delete_title">Delete Recording?</string>


### PR DESCRIPTION
This pull request adds the functionality to fetch and display the audio metadata list from the backend to the mobile app. It includes changes to the ApiService interface to add a new endpoint for fetching the audio metadata list. Additionally, the AudioRepository interface is updated to include a new method for getting the cloud recordings. The LocalRecordingsViewModel is modified to load both local and cloud recordings, and the LibraryScreen is introduced to display the cloud recordings. Various string resources are also added to support the new functionality.