### PR TITLE
Add audio metadata retrieval endpoint

### DIFF
--- a/backend/audioscholar/src/main/resources/application.properties
+++ b/backend/audioscholar/src/main/resources/application.properties
@@ -9,7 +9,12 @@ firebase.firestore.collection.audiometadata=audio_metadata
 
 # Nhost Configuration
 # Use the exact URL from your Nhost environment variables
-nhost.storage.url=https://jcrywhcmpyxmjsgyligr.storage.ap-southeast-1.nhost.run/v1/files
+
+#Orlanes
+#nhost.storage.url=https://jcrywhcmpyxmjsgyligr.storage.ap-southeast-1.nhost.run/v1/files
+
+#Biacolo
+nhost.storage.url=https://oxhxfapvobuzkdjmhlby.storage.ap-southeast-1.nhost.run/v1/files
 # Reference the admin secret via an environment variable named NHOST_ADMIN_SECRET
 # Spring Boot will automatically pick up the NHOST_ADMIN_SECRET environment variable.
 nhost.storage.admin-secret=${NHOST_ADMIN_SECRET}


### PR DESCRIPTION
This pull request adds a new endpoint to retrieve audio metadata. The `AudioController` class is modified to include a new `getAllMetadata` method that retrieves a list of audio metadata using the `AudioProcessingService`. The method returns the metadata list if successful, otherwise it returns an error response. The necessary changes to the `AudioController` constructor and the `application.properties` file are also included in this pull request.