### PR TITLE
Implement JWT Denylist Filter

### DIFF
--- a/backend/audioscholar/src/main/java/edu/cit/audioscholar/security/JwtDenylistFilter.java
+++ b/backend/audioscholar/src/main/java/edu/cit/audioscholar/security/JwtDenylistFilter.java
@@ -1,0 +1,68 @@
+package edu.cit.audioscholar.security;
+
+import edu.cit.audioscholar.service.TokenRevocationService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtDenylistFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtDenylistFilter.class);
+
+    private final TokenRevocationService tokenRevocationService;
+
+    public JwtDenylistFilter(TokenRevocationService tokenRevocationService) {
+        this.tokenRevocationService = tokenRevocationService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.isAuthenticated()) {
+            String token = extractJwtFromRequest(request);
+
+            if (token != null) {
+                log.debug("Checking if authenticated token is revoked for path: {}", request.getRequestURI());
+                if (tokenRevocationService.isTokenRevoked(token)) {
+                    log.warn("Access denied: Token has been revoked (found in denylist).");
+                    SecurityContextHolder.clearContext();
+                    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                    response.getWriter().write("{\"error\": \"Unauthorized\", \"message\": \"Token has been revoked.\"}");
+                    response.setContentType("application/json");
+                    return;
+                } else {
+                     log.debug("Token is valid (not revoked). Proceeding.");
+                }
+            } else {
+                 log.debug("User is authenticated but no Bearer token found in request? This might indicate session-based auth leaking through.");
+            }
+        } else {
+             log.debug("No authenticated user found in context, skipping denylist check for path: {}", request.getRequestURI());
+        }
+
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/backend/audioscholar/src/main/java/edu/cit/audioscholar/security/JwtTokenProvider.java
+++ b/backend/audioscholar/src/main/java/edu/cit/audioscholar/security/JwtTokenProvider.java
@@ -1,10 +1,9 @@
 package edu.cit.audioscholar.security;
 
 import java.util.Date;
+import java.util.UUID;
 import java.util.stream.Collectors;
-
 import javax.crypto.SecretKey;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,7 +11,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
-
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -38,20 +36,27 @@ public class JwtTokenProvider {
 
     @PostConstruct
     public void init() {
-        if (jwtSecretString == null || jwtSecretString.length() < 32) {
-             logger.warn("JWT Secret is not configured or too short in application properties! Using a default temporary key. PLEASE CONFIGURE a strong 'app.jwt.secret'.");
-             this.jwtSecretKey = Jwts.SIG.HS256.key().build();
+        if (jwtSecretString == null || jwtSecretString.isBlank() || jwtSecretString.length() < 43) {
+            logger.warn("JWT Secret ('app.jwt.secret') is not configured, is blank, or too short (requires >= 43 Base64 chars for HS256)! Using a default temporary key. PLEASE CONFIGURE a strong secret.");
+            this.jwtSecretKey = Jwts.SIG.HS256.key().build();
         } else {
-            byte[] keyBytes = Decoders.BASE64.decode(jwtSecretString);
-            this.jwtSecretKey = Keys.hmacShaKeyFor(keyBytes);
+            try {
+                byte[] keyBytes = Decoders.BASE64.decode(jwtSecretString);
+                this.jwtSecretKey = Keys.hmacShaKeyFor(keyBytes);
+                logger.info("Successfully loaded JWT secret key from configuration.");
+            } catch (IllegalArgumentException e) {
+                logger.error("Invalid Base64 encoding for JWT secret ('app.jwt.secret'). Using a default temporary key. PLEASE FIX the configuration.", e);
+                this.jwtSecretKey = Jwts.SIG.HS256.key().build();
+            }
         }
     }
+
 
     public SecretKey getJwtSecretKey() {
         if (this.jwtSecretKey == null) {
             init();
             if (this.jwtSecretKey == null) {
-                 throw new IllegalStateException("JWT Secret Key is null after initialization attempt.");
+                throw new IllegalStateException("JWT Secret Key is null after initialization attempt.");
             }
         }
         return jwtSecretKey;
@@ -60,8 +65,6 @@ public class JwtTokenProvider {
     public String generateToken(Authentication authentication) {
         Object principal = authentication.getPrincipal();
         String username = authentication.getName();
-
-
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
@@ -70,59 +73,81 @@ public class JwtTokenProvider {
 
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + jwtExpirationMs);
+        String jti = UUID.randomUUID().toString();
 
         String displayName = null;
         if (principal instanceof OAuth2User) {
-             displayName = ((OAuth2User) principal).getAttribute("name");
-             if (displayName == null && ((OAuth2User) principal).getAttribute("login") != null) {
-                 displayName = ((OAuth2User) principal).getAttribute("login");
-             }
+            OAuth2User oauth2User = (OAuth2User) principal;
+            displayName = oauth2User.getAttribute("name");
+            if (displayName == null && oauth2User.getAttribute("login") != null) {
+                displayName = oauth2User.getAttribute("login");
+            }
         }
 
-
         return Jwts.builder()
+                .id(jti)
                 .subject(username)
                 .claim("roles", authorities)
-                .claim("name", displayName)
+                .claim("name", displayName != null ? displayName : "")
                 .issuedAt(now)
                 .expiration(expiryDate)
-                .signWith(jwtSecretKey, Jwts.SIG.HS256)
+                .signWith(getJwtSecretKey(), Jwts.SIG.HS256)
                 .compact();
     }
 
-    public String getUsernameFromJWT(String token) {
+    public String getUserIdFromJWT(String token) {
         Claims claims = Jwts.parser()
-                .verifyWith(jwtSecretKey)
+                .verifyWith(getJwtSecretKey())
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
-
         return claims.getSubject();
     }
 
+    public String getJtiFromJWT(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(getJwtSecretKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return claims.getId();
+    }
+
+    public Date getExpirationDateFromJWT(String token) {
+         Claims claims = Jwts.parser()
+                .verifyWith(getJwtSecretKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return claims.getExpiration();
+    }
+
+
     public boolean validateToken(String authToken) {
         try {
-            Jwts.parser().verifyWith(jwtSecretKey).build().parseSignedClaims(authToken);
+            Jwts.parser().verifyWith(getJwtSecretKey()).build().parseSignedClaims(authToken);
             return true;
         } catch (SignatureException ex) {
             logger.error("Invalid JWT signature: {}", ex.getMessage());
         } catch (MalformedJwtException ex) {
             logger.error("Invalid JWT token: {}", ex.getMessage());
         } catch (ExpiredJwtException ex) {
-            logger.error("Expired JWT token: {}", ex.getMessage());
+            logger.debug("Expired JWT token: {}", ex.getMessage());
         } catch (UnsupportedJwtException ex) {
             logger.error("Unsupported JWT token: {}", ex.getMessage());
         } catch (IllegalArgumentException ex) {
-            logger.error("JWT claims string is empty: {}", ex.getMessage());
+            logger.error("JWT claims string is empty or invalid: {}", ex.getMessage());
+        } catch (Exception e) {
+             logger.error("Unexpected error validating JWT token: {}", e.getMessage(), e);
         }
         return false;
     }
 
     public Claims getClaimsFromJWT(String token) {
          return Jwts.parser()
-                 .verifyWith(jwtSecretKey)
-                 .build()
-                 .parseSignedClaims(token)
-                 .getPayload();
+                .verifyWith(getJwtSecretKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
     }
 }

--- a/backend/audioscholar/src/main/java/edu/cit/audioscholar/service/TokenRevocationService.java
+++ b/backend/audioscholar/src/main/java/edu/cit/audioscholar/service/TokenRevocationService.java
@@ -1,0 +1,146 @@
+package edu.cit.audioscholar.service;
+
+import com.google.cloud.Timestamp; // Import Firestore Timestamp
+import edu.cit.audioscholar.exception.FirestoreInteractionException;
+import edu.cit.audioscholar.security.JwtTokenProvider;
+import io.jsonwebtoken.ExpiredJwtException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class TokenRevocationService {
+
+    private static final Logger log = LoggerFactory.getLogger(TokenRevocationService.class);
+    private static final String DENYLIST_COLLECTION = "jwt_denylist";
+
+    private final FirebaseService firebaseService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    public TokenRevocationService(FirebaseService firebaseService, JwtTokenProvider jwtTokenProvider) {
+        this.firebaseService = firebaseService;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    /**
+     * Adds the given JWT's ID (jti) to the denylist in Firestore.
+     * The entry will implicitly expire based on Firestore cleanup rules or manual cleanup.
+     * We store the original expiry time for potential manual cleanup.
+     *
+     * @param token The JWT to revoke.
+     */
+    public void revokeToken(String token) {
+        try {
+            String jti = jwtTokenProvider.getJtiFromJWT(token);
+            Date expirationDate = jwtTokenProvider.getExpirationDateFromJWT(token);
+            long nowMillis = System.currentTimeMillis();
+            long expirationMillis = expirationDate.getTime();
+
+            // Optional: Check if token is already expired before adding to denylist
+            if (expirationMillis <= nowMillis) {
+                log.debug("Token with jti {} is already expired. No need to add to denylist.", jti);
+                return;
+            }
+
+            // Store JTI as document ID, include expiry for potential cleanup
+            Map<String, Object> denylistEntry = new HashMap<>();
+            denylistEntry.put("expiryTimestamp", Timestamp.of(expirationDate)); // Store as Firestore Timestamp
+
+            log.info("Adding token jti {} to denylist with expiry {}", jti, expirationDate);
+            firebaseService.saveData(DENYLIST_COLLECTION, jti, denylistEntry);
+
+        } catch (ExpiredJwtException e) {
+            // If the token is already expired when trying to revoke, it's effectively revoked.
+            log.debug("Attempted to revoke an already expired token (jti: {}).", e.getClaims().getId());
+        } catch (FirestoreInteractionException e) {
+            log.error("Firestore error while adding token jti to denylist: {}", e.getMessage(), e);
+            // Depending on requirements, you might re-throw or handle differently
+        } catch (Exception e) {
+            log.error("Unexpected error while revoking token: {}", e.getMessage(), e);
+            // Handle unexpected JWT parsing errors (Malformed, Signature etc.)
+        }
+    }
+
+    /**
+     * Checks if a JWT's ID (jti) exists in the Firestore denylist.
+     *
+     * @param token The JWT to check.
+     * @return true if the token's jti is found in the denylist, false otherwise.
+     */
+    public boolean isTokenRevoked(String token) {
+        try {
+            String jti = jwtTokenProvider.getJtiFromJWT(token);
+            log.debug("Checking denylist for token jti: {}", jti);
+
+            Map<String, Object> data = firebaseService.getData(DENYLIST_COLLECTION, jti);
+            boolean revoked = data != null;
+
+            if (revoked) {
+                log.warn("Token with jti {} found in denylist. Access denied.", jti);
+            } else {
+                log.debug("Token with jti {} not found in denylist. Access allowed (pending other checks).", jti);
+            }
+            return revoked;
+
+        } catch (ExpiredJwtException e) {
+            // An expired token is implicitly invalid, so it's not "revoked" in the sense of being in the denylist.
+            // The standard JWT validation handles expiration.
+            log.debug("Token is already expired (jti: {}), check is effectively false (handled by standard validation).", e.getClaims().getId());
+            return false;
+        } catch (FirestoreInteractionException e) {
+            log.error("Firestore error while checking denylist for token: {}", e.getMessage(), e);
+            // Fail-safe: If we can't check the denylist, should we deny access?
+            // Returning false allows access if DB fails, true denies access. Choose based on security posture.
+            // Let's deny access if the check fails.
+            return true;
+        } catch (Exception e) {
+            log.error("Unexpected error while checking token revocation status: {}", e.getMessage(), e);
+            // Fail-safe: Deny access on unexpected errors during check.
+            return true;
+        }
+    }
+
+    // --- Optional: Cleanup Method ---
+    // This would need to be triggered periodically (e.g., scheduled task, Cloud Function)
+    /*
+    public void cleanupExpiredDenylistEntries() {
+        log.info("Starting cleanup of expired JWT denylist entries...");
+        try {
+            Timestamp now = Timestamp.now();
+            // Query Firestore for documents where expiryTimestamp <= now
+            // This requires creating an index on expiryTimestamp in Firestore
+            // Example using Query (adapt based on FirebaseService capabilities):
+            // Query query = firebaseService.getFirestore().collection(DENYLIST_COLLECTION)
+            //     .whereLessThanOrEqualTo("expiryTimestamp", now);
+            // ApiFuture<QuerySnapshot> querySnapshot = query.get();
+            // List<QueryDocumentSnapshot> documents = querySnapshot.get().getDocuments();
+
+            // For simplicity, let's assume FirebaseService can provide a way to query
+            // List<Map<String, Object>> expiredEntries = firebaseService.queryCollectionWhereLessThanOrEqual(
+            //      DENYLIST_COLLECTION, "expiryTimestamp", now);
+
+            // int count = 0;
+            // for (Map<String, Object> entry : expiredEntries) {
+            //     String jti = (String) entry.get("jti"); // Assuming jti is stored if not used as ID
+            //     // Or get the document ID if jti is the ID
+            //     // String docId = ...
+            //     if (jti != null) { // or docId
+            //         firebaseService.deleteData(DENYLIST_COLLECTION, jti); // or docId
+            //         count++;
+            //     }
+            // }
+            // log.info("Finished cleanup. Removed {} expired denylist entries.", count);
+
+        } catch (Exception e) {
+             log.error("Error during denylist cleanup: {}", e.getMessage(), e);
+        }
+    }
+    */
+}


### PR DESCRIPTION
This pull request adds a new feature called JWT Denylist Filter. The filter is responsible for checking if an authenticated token has been revoked before allowing access to certain paths. It includes a new class called `JwtDenylistFilter` that extends `OncePerRequestFilter` and overrides the `doFilterInternal` method to perform the necessary checks. The filter is integrated into the `AuthController` class, where it is used to handle the `/logout` endpoint. When a user requests to logout, the filter checks the validity of the bearer token and adds it to the denylist if it is valid. The pull request also includes updates to the `SecurityConfig` class to configure the filter and add it to the security filter chain. This feature enhances the security of the application by preventing revoked tokens from accessing protected resources.

\`\`\`