### PR TITLE
feat: Integrate Spring Boot Get User Profile API (Mobile - Kotlin ViewModel/Repository), Specifically the local caching

### DIFF
--- a/frontend_mobile/AudioScholar/app/build.gradle.kts
+++ b/frontend_mobile/AudioScholar/app/build.gradle.kts
@@ -49,6 +49,7 @@ android {
 }
 
 dependencies {
+    implementation("androidx.datastore:datastore-preferences:1.1.4")
     implementation("io.coil-kt:coil-compose:2.6.0")
 
     implementation(platform("com.google.firebase:firebase-bom:33.12.0"))

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/local/UserDataStore.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/local/UserDataStore.kt
@@ -1,0 +1,74 @@
+package edu.cit.audioscholar.data.local
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import edu.cit.audioscholar.data.remote.dto.UserProfileDto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.userDataStore: DataStore<Preferences> by preferencesDataStore(name = "user_profile")
+
+@Singleton
+class UserDataStore @Inject constructor(@ApplicationContext private val context: Context) {
+
+    private object PreferencesKeys {
+        val USER_ID = stringPreferencesKey("user_id")
+        val USER_EMAIL = stringPreferencesKey("user_email")
+        val USER_DISPLAY_NAME = stringPreferencesKey("user_display_name")
+        val USER_PROFILE_IMAGE_URL = stringPreferencesKey("user_profile_image_url")
+        val USER_FIRST_NAME = stringPreferencesKey("user_first_name")
+        val USER_LAST_NAME = stringPreferencesKey("user_last_name")
+    }
+
+    val userProfileFlow: Flow<UserProfileDto?> = context.userDataStore.data
+        .map { preferences ->
+            val userId = preferences[PreferencesKeys.USER_ID]
+            val email = preferences[PreferencesKeys.USER_EMAIL]
+            val displayName = preferences[PreferencesKeys.USER_DISPLAY_NAME]
+            val profileImageUrl = preferences[PreferencesKeys.USER_PROFILE_IMAGE_URL]
+            val firstName = preferences[PreferencesKeys.USER_FIRST_NAME]
+            val lastName = preferences[PreferencesKeys.USER_LAST_NAME]
+
+            if (email != null || userId != null) {
+                UserProfileDto(
+                    userId = userId,
+                    email = email,
+                    displayName = displayName,
+                    profileImageUrl = profileImageUrl,
+                    firstName = firstName,
+                    lastName = lastName
+                )
+            } else {
+                null
+            }
+        }
+
+    suspend fun saveUserProfile(profile: UserProfileDto) {
+        context.userDataStore.edit { preferences ->
+            profile.userId?.let { preferences[PreferencesKeys.USER_ID] = it } ?: preferences.remove(PreferencesKeys.USER_ID)
+            profile.email?.let { preferences[PreferencesKeys.USER_EMAIL] = it } ?: preferences.remove(PreferencesKeys.USER_EMAIL)
+            profile.displayName?.let { preferences[PreferencesKeys.USER_DISPLAY_NAME] = it } ?: preferences.remove(PreferencesKeys.USER_DISPLAY_NAME)
+            profile.profileImageUrl?.let { preferences[PreferencesKeys.USER_PROFILE_IMAGE_URL] = it } ?: preferences.remove(PreferencesKeys.USER_PROFILE_IMAGE_URL)
+            profile.firstName?.let { preferences[PreferencesKeys.USER_FIRST_NAME] = it } ?: preferences.remove(PreferencesKeys.USER_FIRST_NAME)
+            profile.lastName?.let { preferences[PreferencesKeys.USER_LAST_NAME] = it } ?: preferences.remove(PreferencesKeys.USER_LAST_NAME)
+        }
+    }
+
+    suspend fun clearUserProfile() {
+        context.userDataStore.edit { preferences ->
+            preferences.remove(PreferencesKeys.USER_ID)
+            preferences.remove(PreferencesKeys.USER_EMAIL)
+            preferences.remove(PreferencesKeys.USER_DISPLAY_NAME)
+            preferences.remove(PreferencesKeys.USER_PROFILE_IMAGE_URL)
+            preferences.remove(PreferencesKeys.USER_FIRST_NAME)
+            preferences.remove(PreferencesKeys.USER_LAST_NAME)
+        }
+    }
+}

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/AuthRepository.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/AuthRepository.kt
@@ -10,6 +10,7 @@ import edu.cit.audioscholar.data.remote.dto.RegistrationRequest
 import edu.cit.audioscholar.data.remote.dto.UpdateUserProfileRequest
 import edu.cit.audioscholar.data.remote.dto.UserProfileDto
 import edu.cit.audioscholar.util.Resource
+import kotlinx.coroutines.flow.Flow
 
 typealias AuthResult = Resource<AuthResponse>
 typealias UserProfileResult = Resource<UserProfileDto>
@@ -21,9 +22,13 @@ interface AuthRepository {
     suspend fun verifyFirebaseToken(request: FirebaseTokenRequest): AuthResult
     suspend fun verifyGoogleToken(request: FirebaseTokenRequest): AuthResult
     suspend fun verifyGitHubCode(request: GitHubCodeRequest): AuthResult
-    suspend fun getUserProfile(): UserProfileResult
+
+    fun getUserProfile(): Flow<UserProfileResult>
+
     suspend fun updateUserProfile(request: UpdateUserProfileRequest): UserProfileResult
     suspend fun uploadAvatar(imageUri: Uri): UserProfileResult
 
     suspend fun changePassword(request: ChangePasswordRequest): SimpleResult
+
+    suspend fun clearLocalUserCache()
 }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/profile/EditProfileScreen.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/profile/EditProfileScreen.kt
@@ -414,7 +414,7 @@ fun EditProfileScreen(
                             if (!sheetState.isVisible) {
                                 showBottomSheet = false
                                 viewModel.onAvatarUriSelected(null)
-                                viewModel.onProfileImageUrlChange(null)
+                                viewModel.setProfileImageUrl(null)
                             }
                         }
                     }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/profile/UserProfileScreen.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/profile/UserProfileScreen.kt
@@ -105,7 +105,6 @@ fun UserProfileScreen(
                 snackbarHostState.showSnackbar(profileUpdateSuccessMessage)
             }
         }
-        viewModel.loadUserProfile()
     }
 
 
@@ -159,9 +158,9 @@ fun UserProfileScreen(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            if (uiState.isLoading && uiState.name.isEmpty()) {
+            if (uiState.isLoading && !uiState.isDataAvailable) {
                 CircularProgressIndicator(modifier = Modifier.padding(vertical = 16.dp))
-            } else {
+            } else if (uiState.isDataAvailable) {
                 Text(
                     text = uiState.name.ifEmpty { stringResource(R.string.drawer_header_user_name) },
                     style = MaterialTheme.typography.headlineSmall,
@@ -173,15 +172,30 @@ fun UserProfileScreen(
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
+            } else {
+                Text(
+                    text = stringResource(R.string.drawer_header_user_name),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.drawer_header_user_email),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
 
 
             Spacer(modifier = Modifier.height(32.dp))
 
+            val buttonsEnabled = uiState.isDataAvailable
+
             Button(
                 onClick = { navController.navigate(Screen.EditProfile.route) },
                 modifier = Modifier.fillMaxWidth(0.8f),
-                enabled = !uiState.isLoading
+                enabled = buttonsEnabled
             ) {
                 Icon(Icons.Filled.Edit, contentDescription = null, modifier = Modifier.size(ButtonDefaults.IconSize))
                 Spacer(Modifier.size(ButtonDefaults.IconSpacing))
@@ -193,7 +207,7 @@ fun UserProfileScreen(
             Button(
                 onClick = { navController.navigate(Screen.ChangePassword.route) },
                 modifier = Modifier.fillMaxWidth(0.8f),
-                enabled = !uiState.isLoading
+                enabled = buttonsEnabled
             ) {
                 Icon(Icons.Filled.LockReset, contentDescription = null, modifier = Modifier.size(ButtonDefaults.IconSize))
                 Spacer(Modifier.size(ButtonDefaults.IconSpacing))
@@ -206,7 +220,7 @@ fun UserProfileScreen(
                 onClick = { showLogoutDialog = true },
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
-                enabled = !uiState.isLoading
+                enabled = buttonsEnabled
             ) {
                 Icon(Icons.AutoMirrored.Filled.Logout, contentDescription = null, modifier = Modifier.size(ButtonDefaults.IconSize))
                 Spacer(Modifier.size(ButtonDefaults.IconSpacing))

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/profile/UserProfileViewModel.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/profile/UserProfileViewModel.kt
@@ -9,15 +9,20 @@ import edu.cit.audioscholar.domain.repository.AuthRepository
 import edu.cit.audioscholar.ui.auth.LoginViewModel
 import edu.cit.audioscholar.ui.main.SplashActivity
 import edu.cit.audioscholar.util.Resource
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class UserProfileUiState(
     val isLoading: Boolean = false,
+    val isDataAvailable: Boolean = false,
     val name: String = "",
     val email: String = "",
     val profileImageUrl: String? = null,
@@ -34,79 +39,122 @@ class UserProfileViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(UserProfileUiState())
     val uiState: StateFlow<UserProfileUiState> = _uiState.asStateFlow()
 
+    private var loadProfileJob: Job? = null
+
     init {
         loadUserProfile()
     }
 
     fun loadUserProfile() {
-        if (_uiState.value.isLoading) return
+        loadProfileJob?.cancel()
 
-        viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
-            Log.d("UserProfileViewModel", "Calling repository.getUserProfile()")
-            when (val result = authRepository.getUserProfile()) {
-                is Resource.Success -> {
-                    val profileData = result.data
-                    if (profileData != null) {
-                        Log.i("UserProfileViewModel", "Profile loaded successfully: Name=${profileData.displayName}, Email=${profileData.email}")
-                        _uiState.update {
-                            it.copy(
-                                isLoading = false,
-                                name = profileData.displayName ?: "N/A",
-                                email = profileData.email ?: "N/A",
-                                profileImageUrl = profileData.profileImageUrl
-                            )
-                        }
+        loadProfileJob = viewModelScope.launch {
+            Log.d("UserProfileViewModel", "Starting to collect user profile flow.")
+            authRepository.getUserProfile()
+                .onStart {
+                    Log.d("UserProfileViewModel", "Flow started, setting initial loading state if no data yet.")
+                    if (!_uiState.value.isDataAvailable) {
+                        _uiState.update { it.copy(isLoading = true, errorMessage = null) }
                     } else {
-                        Log.w("UserProfileViewModel", "Profile fetch succeeded but data was null")
-                        _uiState.update {
-                            it.copy(
-                                isLoading = false,
-                                errorMessage = "Failed to retrieve profile data."
-                            )
+                        _uiState.update { it.copy(errorMessage = null) }
+                    }
+                }
+                .catch { e ->
+                    Log.e("UserProfileViewModel", "Error collecting profile flow: ${e.message}", e)
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = "An unexpected error occurred: ${e.message}"
+                        )
+                    }
+                }
+                .collect { result ->
+                    Log.d("UserProfileViewModel", "Received profile result: ${result::class.simpleName}")
+                    when (result) {
+                        is Resource.Success -> {
+                            val profileData = result.data
+                            if (profileData != null) {
+                                Log.i("UserProfileViewModel", "Profile loaded/updated: Name=${profileData.displayName}, Email=${profileData.email}")
+                                _uiState.update {
+                                    it.copy(
+                                        isLoading = false,
+                                        isDataAvailable = true,
+                                        name = profileData.displayName ?: "",
+                                        email = profileData.email ?: "",
+                                        profileImageUrl = profileData.profileImageUrl,
+                                        errorMessage = null
+                                    )
+                                }
+                            } else {
+                                Log.w("UserProfileViewModel", "Profile fetch Resource.Success but data was null")
+                                _uiState.update {
+                                    it.copy(
+                                        isLoading = false,
+                                        errorMessage = it.errorMessage ?: "Failed to retrieve profile details."
+                                    )
+                                }
+                            }
+                        }
+                        is Resource.Error -> {
+                            Log.e("UserProfileViewModel", "Error loading profile: ${result.message}")
+                            val currentData = _uiState.value
+                            _uiState.update {
+                                it.copy(
+                                    isLoading = false,
+                                    errorMessage = result.message ?: "An unexpected error occurred."
+                                )
+                            }
+                            if (result.message?.contains("Unauthorized", ignoreCase = true) == true ||
+                                result.message?.contains("401", ignoreCase = true) == true ||
+                                result.message?.contains("403", ignoreCase = true) == true) {
+                                Log.w("UserProfileViewModel", "Unauthorized error detected, clearing session and navigating to login.")
+                                clearSessionAndNavigateToLogin()
+                            }
+                        }
+                        is Resource.Loading -> {
+                            Log.d("UserProfileViewModel", "Profile loading in progress (Resource.Loading)...")
+                            val cachedData = result.data
+                            if (cachedData != null && !_uiState.value.isDataAvailable) {
+                                Log.d("UserProfileViewModel", "Displaying cached data while loading network.")
+                                _uiState.update {
+                                    it.copy(
+                                        isLoading = true,
+                                        isDataAvailable = true,
+                                        name = cachedData.displayName ?: "",
+                                        email = cachedData.email ?: "",
+                                        profileImageUrl = cachedData.profileImageUrl,
+                                        errorMessage = null
+                                    )
+                                }
+                            } else if (!_uiState.value.isDataAvailable) {
+                                _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+                            } else {
+                                _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+                            }
                         }
                     }
                 }
-                is Resource.Error -> {
-                    Log.e("UserProfileViewModel", "Error loading profile: ${result.message}")
-                    if (result.message?.contains("Unauthorized", ignoreCase = true) == true ||
-                        result.message?.contains("401", ignoreCase = true) == true ||
-                        result.message?.contains("403", ignoreCase = true) == true) {
-                        Log.w("UserProfileViewModel", "Unauthorized error detected, clearing session and navigating to login.")
-                        clearSessionAndNavigateToLogin()
-                    } else {
-                        _uiState.update {
-                            it.copy(
-                                isLoading = false,
-                                errorMessage = result.message ?: "An unexpected error occurred while loading the profile."
-                            )
-                        }
-                    }
-                }
-                is Resource.Loading -> {
-                    Log.d("UserProfileViewModel", "Profile loading in progress...")
-                }
-            }
         }
     }
 
     fun logout() {
         viewModelScope.launch {
             Log.d("UserProfileViewModel", "Logout initiated by user")
+            authRepository.clearLocalUserCache()
             clearSessionAndNavigateToLogin()
         }
     }
 
     private fun clearSessionAndNavigateToLogin() {
         viewModelScope.launch {
-            Log.d("UserProfileViewModel", "Clearing local session data.")
+            Log.d("UserProfileViewModel", "Clearing local session data (Prefs).")
             with(prefs.edit()) {
                 remove(LoginViewModel.KEY_AUTH_TOKEN)
                 putBoolean(SplashActivity.KEY_IS_LOGGED_IN, false)
                 apply()
             }
             Log.d("UserProfileViewModel", "Auth token and login status cleared. Triggering navigation.")
-            _uiState.update { it.copy(isLoading = false, navigateToLogin = true) }
+            _uiState.update { UserProfileUiState(navigateToLogin = true) }
         }
     }
 
@@ -116,5 +164,10 @@ class UserProfileViewModel @Inject constructor(
 
     fun consumeErrorMessage() {
         _uiState.update { it.copy(errorMessage = null) }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        loadProfileJob?.cancel()
     }
 }


### PR DESCRIPTION
This pull request integrates the Spring Boot Get User Profile API into the mobile app. Specifically, it focuses on local caching by adding the `androidx.datastore:datastore-preferences:1.1.4` dependency. It also includes changes to the `AuthRepository` interface to use `Flow` for the `getUserProfile` method. Additionally, it updates the `UserProfileScreen` to handle loading states and enables buttons based on the availability of user data. Finally, it introduces the `UserDataStore` class for local data storage and retrieval.