### PR TITLE
feat: Implement Logout Functionality (Main Side Menu) and User Profile view Logout with API

### DIFF
--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/service/ApiService.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/service/ApiService.kt
@@ -75,4 +75,7 @@ interface ApiService {
     suspend fun changePassword(
         @Body changePasswordRequest: ChangePasswordRequest
     ): Response<AuthResponse>
+
+    @POST("/api/auth/logout")
+    suspend fun logout(): Response<Unit>
 }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/AuthRepository.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/AuthRepository.kt
@@ -30,5 +30,7 @@ interface AuthRepository {
 
     suspend fun changePassword(request: ChangePasswordRequest): SimpleResult
 
+    suspend fun logout(): SimpleResult
+
     suspend fun clearLocalUserCache()
 }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/main/MainViewModel.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/main/MainViewModel.kt
@@ -1,21 +1,29 @@
 package edu.cit.audioscholar.ui.main
 
+import android.content.SharedPreferences
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import edu.cit.audioscholar.data.remote.dto.UserProfileDto
 import edu.cit.audioscholar.domain.repository.AuthRepository
+import edu.cit.audioscholar.ui.auth.LoginViewModel
+import edu.cit.audioscholar.ui.main.SplashActivity
 import edu.cit.audioscholar.util.Resource
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val prefs: SharedPreferences
 ) : ViewModel() {
 
     val userProfileState: StateFlow<Resource<UserProfileDto?>> = authRepository.getUserProfile()
@@ -32,10 +40,38 @@ class MainViewModel @Inject constructor(
             initialValue = Resource.Loading<UserProfileDto?>(null)
         )
 
+    private val _logoutCompleteEventChannel = Channel<Unit>(Channel.BUFFERED)
+    val logoutCompleteEventFlow: Flow<Unit> = _logoutCompleteEventChannel.receiveAsFlow()
+
+    fun performLogout() {
+        viewModelScope.launch {
+            Log.d("MainViewModel", "Performing logout: Calling API and clearing cache/prefs.")
+            val result = authRepository.logout()
+            when (result) {
+                is Resource.Success -> Log.i("MainViewModel", "API logout successful.")
+                is Resource.Error -> Log.w("MainViewModel", "API logout failed: ${result.message}. Proceeding with local logout.")
+                is Resource.Loading -> {}
+            }
+
+            authRepository.clearLocalUserCache()
+            Log.d("MainViewModel", "Local user cache cleared.")
+
+            Log.d("MainViewModel", "Clearing SharedPreferences.")
+            with(prefs.edit()) {
+                putBoolean(SplashActivity.KEY_IS_LOGGED_IN, false)
+                remove(LoginViewModel.KEY_AUTH_TOKEN)
+                apply()
+            }
+            Log.d("MainViewModel", "SharedPreferences cleared.")
+
+            Log.d("MainViewModel", "Sending logout complete event.")
+            _logoutCompleteEventChannel.send(Unit)
+        }
+    }
+
     fun clearUserCacheOnLogout() {
         viewModelScope.launch {
             authRepository.clearLocalUserCache()
         }
     }
 }
-

--- a/frontend_mobile/AudioScholar/app/src/main/res/values/strings.xml
+++ b/frontend_mobile/AudioScholar/app/src/main/res/values/strings.xml
@@ -257,6 +257,8 @@
     <string name="onboarding_back">Back</string>
     <string name="onboarding_finish">Finish</string>
 
+    <string name="error_unexpected">An unexpected error occurred: %1$s</string>
+
     <string name="placeholder_username">User Name</string>
     <string name="placeholder_email">user.email@example.com</string>
     <string name="desc_user_avatar">User avatar</string>


### PR DESCRIPTION
This pull request adds the implementation of the Logout functionality to the main side menu and user profile view. It includes changes to the `AuthRepository` interface, `ApiService` interface, `strings.xml` file, `AuthRepositoryImpl` class, and `UserProfileViewModel` class. The `logout()` function in the `AuthRepositoryImpl` class makes an API call to log out the user, and the `logout()` function in the `UserProfileViewModel` class handles the logout process by calling the API and clearing the local user cache. Additionally, the `MainViewModel` class now has a `performLogout()` function that performs the logout process by calling the API, clearing the cache, and clearing the `SharedPreferences`. This pull request also includes the necessary changes to the `MainViewModel` class to handle the logout complete event.

\`\`\`