### PR TITLE
Implement recording details screen integration with backend API

### DIFF
--- a/frontend_mobile/AudioScholar/app/build.gradle.kts
+++ b/frontend_mobile/AudioScholar/app/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
     implementation("io.coil-kt:coil-compose:2.6.0")
 
     implementation("androidx.datastore:datastore-preferences:1.1.4")
-    implementation("io.coil-kt:coil-compose:2.6.0")
 
     implementation(platform("com.google.firebase:firebase-bom:33.12.0"))
     implementation(libs.firebase.auth.ktx)

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/local/model/RecordingMetadata.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/local/model/RecordingMetadata.kt
@@ -1,10 +1,19 @@
 package edu.cit.audioscholar.data.local.model
 
+import edu.cit.audioscholar.data.remote.dto.GlossaryItemDto
+import edu.cit.audioscholar.data.remote.dto.RecommendationDto
+
 data class RecordingMetadata(
     val id: Long = 0,
     val filePath: String,
     val fileName: String,
     val title: String?,
     val timestampMillis: Long,
-    val durationMillis: Long
+    val durationMillis: Long,
+    val remoteRecordingId: String? = null,
+
+    val cachedSummaryText: String? = null,
+    val cachedGlossaryItems: List<GlossaryItemDto>? = null,
+    val cachedRecommendations: List<RecommendationDto>? = null,
+    val cacheTimestampMillis: Long? = null
 )

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/dto/AudioMetadataDto.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/dto/AudioMetadataDto.kt
@@ -15,5 +15,8 @@ data class AudioMetadataDto(
     val description: String? = null,
     val nhostFileId: String? = null,
     val storageUrl: String? = null,
-    val uploadTimestamp: TimestampDto? = null
+    val uploadTimestamp: TimestampDto? = null,
+    val status: String? = null,
+    val recordingId: String? = null,
+    val summaryId: String? = null
 )

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/dto/GlossaryItemDto.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/dto/GlossaryItemDto.kt
@@ -1,0 +1,11 @@
+package edu.cit.audioscholar.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class GlossaryItemDto(
+    @SerializedName("term")
+    val term: String? = null,
+
+    @SerializedName("definition")
+    val definition: String? = null
+)

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/dto/RecommendationDto.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/dto/RecommendationDto.kt
@@ -1,0 +1,26 @@
+package edu.cit.audioscholar.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class RecommendationDto(
+    @SerializedName("recommendationId")
+    val recommendationId: String? = null,
+
+    @SerializedName("videoId")
+    val videoId: String? = null,
+
+    @SerializedName("title")
+    val title: String? = null,
+
+    @SerializedName("descriptionSnippet")
+    val descriptionSnippet: String? = null,
+
+    @SerializedName("thumbnailUrl")
+    val thumbnailUrl: String? = null,
+
+    @SerializedName("recordingId")
+    val recordingId: String? = null,
+
+    @SerializedName("createdAt")
+    val createdAt: String? = null
+)

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/dto/SummaryResponseDto.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/dto/SummaryResponseDto.kt
@@ -1,0 +1,26 @@
+package edu.cit.audioscholar.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class SummaryResponseDto(
+    @SerializedName("summaryId")
+    val summaryId: String? = null,
+
+    @SerializedName("recordingId")
+    val recordingId: String? = null,
+
+    @SerializedName("keyPoints")
+    val keyPoints: List<String>? = null,
+
+    @SerializedName("topics")
+    val topics: List<String>? = null,
+
+    @SerializedName("glossary")
+    val glossary: List<GlossaryItemDto>? = null,
+
+    @SerializedName("formattedSummaryText")
+    val formattedSummaryText: String? = null,
+
+    @SerializedName("createdAt")
+    val createdAt: String? = null
+)

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/service/ApiService.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/data/remote/service/ApiService.kt
@@ -1,23 +1,10 @@
 package edu.cit.audioscholar.data.remote.service
 
-import edu.cit.audioscholar.data.remote.dto.AudioMetadataDto
-import edu.cit.audioscholar.data.remote.dto.AuthResponse
-import edu.cit.audioscholar.data.remote.dto.ChangePasswordRequest
-import edu.cit.audioscholar.data.remote.dto.FirebaseTokenRequest
-import edu.cit.audioscholar.data.remote.dto.GitHubCodeRequest
-import edu.cit.audioscholar.data.remote.dto.LoginRequest
-import edu.cit.audioscholar.data.remote.dto.RegistrationRequest
-import edu.cit.audioscholar.data.remote.dto.UpdateUserProfileRequest
-import edu.cit.audioscholar.data.remote.dto.UserProfileDto
+import edu.cit.audioscholar.data.remote.dto.*
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.Response
-import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.Multipart
-import retrofit2.http.POST
-import retrofit2.http.PUT
-import retrofit2.http.Part
+import retrofit2.http.*
 
 interface ApiService {
 
@@ -78,4 +65,14 @@ interface ApiService {
 
     @POST("/api/auth/logout")
     suspend fun logout(): Response<Unit>
+
+    @GET("/api/recordings/{recordingId}/summary")
+    suspend fun getRecordingSummary(
+        @Path("recordingId") recordingId: String
+    ): Response<SummaryResponseDto>
+
+    @GET("/api/v1/recommendations/recording/{recordingId}")
+    suspend fun getRecordingRecommendations(
+        @Path("recordingId") recordingId: String
+    ): Response<List<RecommendationDto>>
 }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/LocalAudioRepository.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/LocalAudioRepository.kt
@@ -10,6 +10,8 @@ interface LocalAudioRepository {
     suspend fun deleteLocalRecording(metadata: RecordingMetadata): Boolean
     suspend fun deleteLocalRecordings(filePaths: List<String>): Boolean
     suspend fun updateRecordingTitle(filePath: String, newTitle: String): Boolean
-
+    suspend fun updateRemoteRecordingId(localFilePath: String, remoteId: String): Boolean
     suspend fun importAudioFile(sourceUri: Uri, title: String?, description: String?): Result<RecordingMetadata>
+
+    suspend fun saveMetadata(metadata: RecordingMetadata): Boolean
 }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/LocalAudioRepositoryImpl.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/LocalAudioRepositoryImpl.kt
@@ -10,15 +10,12 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import edu.cit.audioscholar.data.local.file.RecordingFileHandler
 import edu.cit.audioscholar.data.local.model.RecordingMetadata
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
 import java.text.ParseException
 import java.text.SimpleDateFormat
-import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -38,21 +35,32 @@ class LocalAudioRepositoryImpl @Inject constructor(
     private val recordingFileHandler: RecordingFileHandler
 ) : LocalAudioRepository {
 
+    private fun getJsonFileForAudio(audioFilePath: String): File? {
+        val audioFile = File(audioFilePath)
+        val recordingsDir = audioFile.parentFile ?: return null
+        val fileName = audioFile.name
+        val fileExtension = SUPPORTED_LOCAL_AUDIO_EXTENSIONS.firstOrNull { fileName.endsWith(it, ignoreCase = true) } ?: ""
+        if (fileExtension.isEmpty()) return null
+        val baseName = fileName.removeSuffix(fileExtension)
+        val jsonFileName = "$baseName$FILENAME_EXTENSION_METADATA"
+        return File(recordingsDir, jsonFileName)
+    }
+
     override fun getRecordingMetadata(filePath: String): Flow<Result<RecordingMetadata>> = flow {
-        val file = File(filePath)
-        if (!file.exists() || !file.isFile) {
+        val audioFile = File(filePath)
+        if (!audioFile.exists() || !audioFile.isFile) {
             emit(Result.failure(IOException("File not found or is not a valid file: $filePath")))
             return@flow
         }
 
-        val fileName = file.name
+        val fileName = audioFile.name
         val isSupported = SUPPORTED_LOCAL_AUDIO_EXTENSIONS.any { fileName.endsWith(it, ignoreCase = true) }
         if (!isSupported) {
             emit(Result.failure(IOException("Unsupported file type: $fileName")))
             return@flow
         }
 
-        val recordingsDir = file.parentFile
+        val recordingsDir = audioFile.parentFile
         if (recordingsDir == null) {
             emit(Result.failure(IOException("Could not determine parent directory for: $filePath")))
             return@flow
@@ -67,10 +75,10 @@ class LocalAudioRepositoryImpl @Inject constructor(
             val timestampString = baseNameWithTimestamp.removePrefix(FILENAME_PREFIX)
 
             val timestampMillis = try {
-                dateFormat.parse(timestampString)?.time ?: file.lastModified()
+                dateFormat.parse(timestampString)?.time ?: audioFile.lastModified()
             } catch (e: ParseException) {
                 Log.w(TAG_LOCAL_REPO, "Could not parse timestamp from filename: $fileName", e)
-                file.lastModified()
+                audioFile.lastModified()
             }
 
             var durationMillis: Long
@@ -90,37 +98,31 @@ class LocalAudioRepositoryImpl @Inject constructor(
                 }
             }
 
-            val jsonFileName = "$baseNameWithTimestamp$FILENAME_EXTENSION_METADATA"
-            val jsonFile = File(recordingsDir, jsonFileName)
-            var titleFromFile: String? = null
+            val jsonFile = getJsonFileForAudio(filePath)
             var parsedMetadata: RecordingMetadata? = null
 
-            if (jsonFile.exists() && jsonFile.isFile) {
+            if (jsonFile != null && jsonFile.exists() && jsonFile.isFile) {
                 try {
                     val jsonContent = jsonFile.readText()
                     parsedMetadata = gson.fromJson(jsonContent, RecordingMetadata::class.java)
-                    titleFromFile = parsedMetadata?.title
                     Log.d(TAG_LOCAL_REPO,"Successfully parsed metadata from ${jsonFile.name}")
                 } catch (e: Exception) {
                     Log.e(TAG_LOCAL_REPO, "Failed to read or parse JSON metadata file: ${jsonFile.name}", e)
-                    try {
-                        if (jsonFile.readText().contains("\"title\"")) {
-                            titleFromFile = jsonFile.readText().split("\"title\":\"")[1].split("\"")[0]
-                            Log.w(TAG_LOCAL_REPO,"Parsed title using fallback string split for ${jsonFile.name}")
-                        }
-                    } catch (splitError: Exception) {
-                        Log.e(TAG_LOCAL_REPO, "Fallback string split for title also failed for ${jsonFile.name}", splitError)
-                    }
                 }
             }
 
             val finalMetadata = RecordingMetadata(
-                id = timestampMillis,
+                id = parsedMetadata?.id ?: timestampMillis,
                 filePath = filePath,
                 fileName = fileName,
-                title = titleFromFile ?: baseNameWithTimestamp.removePrefix(FILENAME_PREFIX).replace("_", " "),
+                title = parsedMetadata?.title ?: baseNameWithTimestamp.removePrefix(FILENAME_PREFIX).replace("_", " "),
                 timestampMillis = timestampMillis,
-                durationMillis = if (parsedMetadata != null && parsedMetadata.durationMillis > 0) parsedMetadata.durationMillis else durationMillis
+                durationMillis = if (parsedMetadata != null && parsedMetadata.durationMillis > 0) parsedMetadata.durationMillis else durationMillis,
+                remoteRecordingId = parsedMetadata?.remoteRecordingId,
+                cachedSummaryText = parsedMetadata?.cachedSummaryText,
+                cachedGlossaryItems = parsedMetadata?.cachedGlossaryItems,
+                cachedRecommendations = parsedMetadata?.cachedRecommendations,
+                cacheTimestampMillis = parsedMetadata?.cacheTimestampMillis
             )
             metadataResult = Result.success(finalMetadata)
 
@@ -173,46 +175,38 @@ class LocalAudioRepositoryImpl @Inject constructor(
                     retriever.setDataSource(filePath)
                     retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLongOrNull() ?: 0L
                 } catch (e: Exception) {
-                    Log.e(TAG_LOCAL_REPO, "Failed to get duration for file: $fileName", e)
                     0L
                 }
 
-                val jsonFileName = "$baseNameWithTimestamp$FILENAME_EXTENSION_METADATA"
-                val jsonFile = File(recordingsDir, jsonFileName)
-                var titleFromFile: String? = null
+                val jsonFile = getJsonFileForAudio(filePath)
                 var parsedMetadata: RecordingMetadata? = null
 
-                if (jsonFile.exists() && jsonFile.isFile) {
+                if (jsonFile != null && jsonFile.exists() && jsonFile.isFile) {
                     try {
                         val jsonContent = jsonFile.readText()
                         parsedMetadata = gson.fromJson(jsonContent, RecordingMetadata::class.java)
-                        titleFromFile = parsedMetadata?.title
-                        Log.d(TAG_LOCAL_REPO,"Successfully parsed metadata from ${jsonFile.name}")
                     } catch (e: Exception) {
                         Log.e(TAG_LOCAL_REPO, "Failed to read or parse JSON metadata file: ${jsonFile.name}", e)
-                        try {
-                            if (jsonFile.readText().contains("\"title\"")) {
-                                titleFromFile = jsonFile.readText().split("\"title\":\"")[1].split("\"")[0]
-                                Log.w(TAG_LOCAL_REPO,"Parsed title using fallback string split for ${jsonFile.name}")
-                            }
-                        } catch (splitError: Exception) {
-                            Log.e(TAG_LOCAL_REPO, "Fallback string split for title also failed for ${jsonFile.name}", splitError)
-                        }
                     }
                 }
 
                 metadataList.add(
                     RecordingMetadata(
-                        id = timestampMillis,
+                        id = parsedMetadata?.id ?: timestampMillis,
                         filePath = filePath,
                         fileName = fileName,
-                        title = titleFromFile ?: baseNameWithTimestamp.removePrefix(FILENAME_PREFIX).replace("_", " "),
+                        title = parsedMetadata?.title ?: baseNameWithTimestamp.removePrefix(FILENAME_PREFIX).replace("_", " "),
                         timestampMillis = timestampMillis,
-                        durationMillis = if (parsedMetadata != null && parsedMetadata.durationMillis > 0) parsedMetadata.durationMillis else durationMillis
+                        durationMillis = if (parsedMetadata != null && parsedMetadata.durationMillis > 0) parsedMetadata.durationMillis else durationMillis,
+                        remoteRecordingId = parsedMetadata?.remoteRecordingId,
+                        cachedSummaryText = parsedMetadata?.cachedSummaryText,
+                        cachedGlossaryItems = parsedMetadata?.cachedGlossaryItems,
+                        cachedRecommendations = parsedMetadata?.cachedRecommendations,
+                        cacheTimestampMillis = parsedMetadata?.cacheTimestampMillis
                     )
                 )
             } catch (e: Exception) {
-                Log.e(TAG_LOCAL_REPO, "Error processing file: ${file.name}", e)
+                Log.e(TAG_LOCAL_REPO, "Error processing file in list: ${file.name}", e)
             }
         }
         try {
@@ -228,196 +222,54 @@ class LocalAudioRepositoryImpl @Inject constructor(
 
     }.flowOn(Dispatchers.IO)
 
-
-    override suspend fun deleteLocalRecording(metadata: RecordingMetadata): Boolean = withContext(Dispatchers.IO) {
-        var audioDeleted = false
-        var jsonDeletedOrNotFound = true
+    override suspend fun saveMetadata(metadata: RecordingMetadata): Boolean = withContext(Dispatchers.IO) {
+        val jsonFile = getJsonFileForAudio(metadata.filePath)
+        if (jsonFile == null) {
+            Log.e(TAG_LOCAL_REPO, "Could not determine JSON file path for audio: ${metadata.filePath}")
+            return@withContext false
+        }
 
         try {
-            val audioFile = File(metadata.filePath)
-            if (audioFile.exists()) {
-                audioDeleted = audioFile.delete()
-                if (audioDeleted) {
-                    Log.i(TAG_LOCAL_REPO, "Successfully deleted audio file: ${metadata.fileName}")
-                } else {
-                    Log.w(TAG_LOCAL_REPO, "Failed to delete audio file: ${metadata.fileName}")
-                    return@withContext false
-                }
-            } else {
-                Log.w(TAG_LOCAL_REPO, "Audio file not found for deletion (considered success for overall operation): ${metadata.filePath}")
-                audioDeleted = true
-            }
+            val jsonContent = gson.toJson(metadata)
+            jsonFile.writeText(jsonContent)
+            Log.i(TAG_LOCAL_REPO, "Successfully saved metadata to ${jsonFile.name}")
+            return@withContext true
+        } catch (e: IOException) {
+            Log.e(TAG_LOCAL_REPO, "IOException saving metadata to ${jsonFile.name}", e)
+            return@withContext false
         } catch (e: SecurityException) {
-            Log.e(TAG_LOCAL_REPO, "SecurityException during audio file deletion: ${metadata.fileName}", e)
+            Log.e(TAG_LOCAL_REPO, "SecurityException saving metadata to ${jsonFile.name}", e)
             return@withContext false
         } catch (e: Exception) {
-            Log.e(TAG_LOCAL_REPO, "Error deleting audio file: ${metadata.fileName}", e)
+            Log.e(TAG_LOCAL_REPO, "Unexpected error saving metadata to ${jsonFile.name}", e)
             return@withContext false
         }
-
-        if (audioDeleted) {
-            try {
-                val fileExtension = SUPPORTED_LOCAL_AUDIO_EXTENSIONS.firstOrNull { metadata.fileName.endsWith(it, ignoreCase = true) } ?: ""
-                val baseName = metadata.fileName.removeSuffix(fileExtension)
-                val jsonFileName = "$baseName$FILENAME_EXTENSION_METADATA"
-
-                val recordingsDir = File(metadata.filePath).parentFile
-
-                if (recordingsDir != null) {
-                    val jsonFile = File(recordingsDir, jsonFileName)
-                    if (jsonFile.exists()) {
-                        jsonDeletedOrNotFound = jsonFile.delete()
-                        if (jsonDeletedOrNotFound) {
-                            Log.i(TAG_LOCAL_REPO, "Successfully deleted metadata file: ${jsonFile.name}")
-                        } else {
-                            Log.w(TAG_LOCAL_REPO, "Failed to delete metadata file: ${jsonFile.name}")
-                        }
-                    } else {
-                        Log.i(TAG_LOCAL_REPO, "Metadata file not found (considered success): ${jsonFile.name}")
-                        jsonDeletedOrNotFound = true
-                    }
-                } else {
-                    Log.w(TAG_LOCAL_REPO, "Could not get parent directory to find/delete JSON file for ${metadata.fileName}.")
-                    jsonDeletedOrNotFound = false
-                }
-            } catch (e: SecurityException) {
-                Log.e(TAG_LOCAL_REPO, "SecurityException during JSON file deletion: ${metadata.fileName.replaceAfterLast('.', FILENAME_EXTENSION_METADATA)}", e)
-                jsonDeletedOrNotFound = false
-            } catch (e: Exception) {
-                Log.e(TAG_LOCAL_REPO, "Error deleting JSON file: ${metadata.fileName.replaceAfterLast('.', FILENAME_EXTENSION_METADATA)}", e)
-                jsonDeletedOrNotFound = false
-            }
-        }
-
-        return@withContext jsonDeletedOrNotFound
     }
-
-
-    override suspend fun deleteLocalRecordings(filePaths: List<String>): Boolean = withContext(Dispatchers.IO) {
-        var allSucceeded = true
-        Log.i(TAG_LOCAL_REPO, "Attempting to delete ${filePaths.size} recordings.")
-
-        for (filePath in filePaths) {
-            val file = File(filePath)
-            if (!file.exists()) {
-                Log.w(TAG_LOCAL_REPO, "Multi-delete: File not found, skipping: $filePath")
-                continue
-            }
-            val fileName = file.name
-
-            var audioDeleted = false
-            var jsonDeletedOrNotFound = true
-
-            try {
-                audioDeleted = file.delete()
-                if (!audioDeleted) {
-                    Log.w(TAG_LOCAL_REPO, "Multi-delete: Failed to delete audio file: $fileName")
-                    allSucceeded = false
-                    continue
-                }
-                Log.i(TAG_LOCAL_REPO, "Multi-delete: Successfully deleted audio file: $fileName")
-            } catch (e: SecurityException) {
-                Log.e(TAG_LOCAL_REPO, "Multi-delete: SecurityException during audio file deletion: $fileName", e)
-                allSucceeded = false
-                continue
-            } catch (e: Exception) {
-                Log.e(TAG_LOCAL_REPO, "Multi-delete: Error deleting audio file: $fileName", e)
-                allSucceeded = false
-                continue
-            }
-
-            try {
-                val fileExtension = SUPPORTED_LOCAL_AUDIO_EXTENSIONS.firstOrNull { fileName.endsWith(it, ignoreCase = true) } ?: ""
-                val baseName = fileName.removeSuffix(fileExtension)
-                val jsonFileName = "$baseName$FILENAME_EXTENSION_METADATA"
-
-                val recordingsDir = file.parentFile
-                if (recordingsDir != null && recordingsDir.isDirectory) {
-                    val jsonFile = File(recordingsDir, jsonFileName)
-                    if (jsonFile.exists()) {
-                        jsonDeletedOrNotFound = jsonFile.delete()
-                        if (jsonDeletedOrNotFound) {
-                            Log.i(TAG_LOCAL_REPO, "Multi-delete: Successfully deleted metadata file: ${jsonFile.name}")
-                        } else {
-                            Log.w(TAG_LOCAL_REPO, "Multi-delete: Failed to delete metadata file: ${jsonFile.name}")
-                            allSucceeded = false
-                        }
-                    } else {
-                        Log.i(TAG_LOCAL_REPO, "Multi-delete: Metadata file not found (considered success): ${jsonFile.name}")
-                        jsonDeletedOrNotFound = true
-                    }
-                } else {
-                    Log.w(TAG_LOCAL_REPO, "Multi-delete: Could not get parent directory for $fileName to find/delete JSON file.")
-                    jsonDeletedOrNotFound = false
-                    allSucceeded = false
-                }
-            } catch (e: SecurityException) {
-                Log.e(TAG_LOCAL_REPO, "Multi-delete: SecurityException during JSON file deletion for $fileName", e)
-                allSucceeded = false
-            } catch (e: Exception) {
-                Log.e(TAG_LOCAL_REPO, "Multi-delete: Error deleting JSON file for $fileName", e)
-            }
-        }
-        Log.i(TAG_LOCAL_REPO, "Multi-delete operation finished. Overall success: $allSucceeded")
-        return@withContext allSucceeded
-    }
-
 
     override suspend fun updateRecordingTitle(filePath: String, newTitle: String): Boolean = withContext(Dispatchers.IO) {
         Log.d(TAG_LOCAL_REPO, "Attempting to update title for $filePath to '$newTitle'")
-        val audioFile = File(filePath)
-        if (!audioFile.exists()) {
-            Log.e(TAG_LOCAL_REPO, "Audio file not found: $filePath")
-            return@withContext false
+        var success = false
+        getRecordingMetadata(filePath).firstOrNull()?.onSuccess { currentMetadata ->
+            val updatedMetadata = currentMetadata.copy(title = newTitle)
+            success = saveMetadata(updatedMetadata)
+        }?.onFailure { e ->
+            Log.e(TAG_LOCAL_REPO, "Failed to get current metadata to update title for $filePath", e)
+            success = false
         }
+        return@withContext success
+    }
 
-        val recordingsDir = audioFile.parentFile
-        if (recordingsDir == null || !recordingsDir.isDirectory) {
-            Log.e(TAG_LOCAL_REPO, "Could not determine parent directory for: $filePath")
-            return@withContext false
+    override suspend fun updateRemoteRecordingId(localFilePath: String, remoteId: String): Boolean = withContext(Dispatchers.IO) {
+        Log.d(TAG_LOCAL_REPO, "Attempting to update remoteRecordingId for $localFilePath to '$remoteId'")
+        var success = false
+        getRecordingMetadata(localFilePath).firstOrNull()?.onSuccess { currentMetadata ->
+            val updatedMetadata = currentMetadata.copy(remoteRecordingId = remoteId)
+            success = saveMetadata(updatedMetadata)
+        }?.onFailure { e ->
+            Log.e(TAG_LOCAL_REPO, "Failed to get current metadata to update remoteId for $localFilePath", e)
+            success = false
         }
-
-        val fileName = audioFile.name
-        val fileExtension = SUPPORTED_LOCAL_AUDIO_EXTENSIONS.firstOrNull { fileName.endsWith(it, ignoreCase = true) } ?: ""
-        val baseName = fileName.removeSuffix(fileExtension)
-        val jsonFileName = "$baseName$FILENAME_EXTENSION_METADATA"
-        val jsonFile = File(recordingsDir, jsonFileName)
-
-        try {
-            val metadata: RecordingMetadata = if (jsonFile.exists() && jsonFile.isFile) {
-                try {
-                    val jsonContent = jsonFile.readText()
-                    gson.fromJson(jsonContent, RecordingMetadata::class.java) ?: run {
-                        Log.w(TAG_LOCAL_REPO, "JSON file exists but failed to parse: ${jsonFile.name}. Creating new metadata object.")
-                        createFallbackMetadata(audioFile, baseName, newTitle)
-                    }
-                } catch (e: Exception) {
-                    Log.e(TAG_LOCAL_REPO, "Error reading/parsing existing JSON file: ${jsonFile.name}", e)
-                    createFallbackMetadata(audioFile, baseName, newTitle)
-                }
-            } else {
-                Log.w(TAG_LOCAL_REPO, "JSON file not found: ${jsonFile.name}. Creating new metadata object.")
-                createFallbackMetadata(audioFile, baseName, newTitle)
-            }
-
-            val updatedMetadata = metadata.copy(title = newTitle)
-
-            val updatedJsonContent = gson.toJson(updatedMetadata)
-            jsonFile.writeText(updatedJsonContent)
-
-            Log.i(TAG_LOCAL_REPO, "Successfully updated title in metadata file: ${jsonFile.name}")
-            return@withContext true
-
-        } catch (e: IOException) {
-            Log.e(TAG_LOCAL_REPO, "IOException during title update for ${jsonFile.name}", e)
-            return@withContext false
-        } catch (e: SecurityException) {
-            Log.e(TAG_LOCAL_REPO, "SecurityException during title update for ${jsonFile.name}", e)
-            return@withContext false
-        } catch (e: Exception) {
-            Log.e(TAG_LOCAL_REPO, "Unexpected error during title update for ${jsonFile.name}", e)
-            return@withContext false
-        }
+        return@withContext success
     }
 
     override suspend fun importAudioFile(sourceUri: Uri, title: String?, description: String?): Result<RecordingMetadata> = withContext(Dispatchers.IO) {
@@ -456,7 +308,7 @@ class LocalAudioRepositoryImpl @Inject constructor(
         val timestampMillis = System.currentTimeMillis()
         val fileName = destinationFile.name
         val finalTitle = if (title.isNullOrBlank()) {
-            fileName.substringBeforeLast('.', fileName)
+            fileName.substringBeforeLast('.', fileName).replace("_", " ").removePrefix("Recording ")
         } else {
             title
         }
@@ -467,40 +319,97 @@ class LocalAudioRepositoryImpl @Inject constructor(
             fileName = fileName,
             title = finalTitle,
             timestampMillis = timestampMillis,
-            durationMillis = durationMillis
+            durationMillis = durationMillis,
+            remoteRecordingId = null,
+            cachedSummaryText = null,
+            cachedGlossaryItems = null,
+            cachedRecommendations = null,
+            cacheTimestampMillis = null
         )
-        Log.d(TAG_LOCAL_REPO, "Created metadata object: $metadata")
+        Log.d(TAG_LOCAL_REPO, "Created metadata object for import: $metadata")
 
-        val recordingsDir = destinationFile.parentFile
-        if (recordingsDir == null) {
-            Log.e(TAG_LOCAL_REPO, "Could not get parent directory for ${destinationFile.name} to save JSON.")
+        val saved = saveMetadata(metadata)
+
+        if (saved) {
+            Log.i(TAG_LOCAL_REPO, "Successfully saved initial metadata for imported file.")
+            return@withContext Result.success(metadata)
+        } else {
+            Log.e(TAG_LOCAL_REPO, "Failed to save initial metadata for imported file.")
             destinationFile.delete()
-            return@withContext Result.failure(IOException("Failed to get recordings directory"))
+            return@withContext Result.failure(IOException("Failed to save metadata for imported file"))
         }
+    }
 
-        val fileExtension = SUPPORTED_LOCAL_AUDIO_EXTENSIONS.firstOrNull { fileName.endsWith(it, ignoreCase = true) } ?: ""
-        val baseName = fileName.removeSuffix(fileExtension)
-        val jsonFileName = "$baseName$FILENAME_EXTENSION_METADATA"
-        val jsonFile = File(recordingsDir, jsonFileName)
+
+    override suspend fun deleteLocalRecording(metadata: RecordingMetadata): Boolean = withContext(Dispatchers.IO) {
+        var audioDeleted = false
+        var jsonDeletedOrNotFound = true
 
         try {
-            val jsonContent = gson.toJson(metadata)
-            jsonFile.writeText(jsonContent)
-            Log.i(TAG_LOCAL_REPO, "Successfully saved metadata to ${jsonFile.name}")
-            return@withContext Result.success(metadata)
-        } catch (e: IOException) {
-            Log.e(TAG_LOCAL_REPO, "IOException saving JSON metadata for ${jsonFile.name}", e)
-            destinationFile.delete()
-            return@withContext Result.failure(e)
+            val audioFile = File(metadata.filePath)
+            if (audioFile.exists()) {
+                audioDeleted = audioFile.delete()
+                if (audioDeleted) {
+                    Log.i(TAG_LOCAL_REPO, "Successfully deleted audio file: ${metadata.fileName}")
+                } else {
+                    Log.w(TAG_LOCAL_REPO, "Failed to delete audio file: ${metadata.fileName}")
+                    return@withContext false
+                }
+            } else {
+                Log.w(TAG_LOCAL_REPO, "Audio file not found for deletion (considered success for overall operation): ${metadata.filePath}")
+                audioDeleted = true
+            }
         } catch (e: SecurityException) {
-            Log.e(TAG_LOCAL_REPO, "SecurityException saving JSON metadata for ${jsonFile.name}", e)
-            destinationFile.delete()
-            return@withContext Result.failure(e)
+            Log.e(TAG_LOCAL_REPO, "SecurityException during audio file deletion: ${metadata.fileName}", e)
+            return@withContext false
         } catch (e: Exception) {
-            Log.e(TAG_LOCAL_REPO, "Unexpected error saving JSON metadata for ${jsonFile.name}", e)
-            destinationFile.delete()
-            return@withContext Result.failure(e)
+            Log.e(TAG_LOCAL_REPO, "Error deleting audio file: ${metadata.fileName}", e)
+            return@withContext false
         }
+
+        if (audioDeleted) {
+            val jsonFile = getJsonFileForAudio(metadata.filePath)
+            if (jsonFile != null) {
+                try {
+                    if (jsonFile.exists()) {
+                        jsonDeletedOrNotFound = jsonFile.delete()
+                        if (jsonDeletedOrNotFound) {
+                            Log.i(TAG_LOCAL_REPO, "Successfully deleted metadata file: ${jsonFile.name}")
+                        } else {
+                            Log.w(TAG_LOCAL_REPO, "Failed to delete metadata file: ${jsonFile.name}")
+                        }
+                    } else {
+                        Log.i(TAG_LOCAL_REPO, "Metadata file not found (considered success): ${jsonFile.name}")
+                        jsonDeletedOrNotFound = true
+                    }
+                } catch (e: SecurityException) {
+                    Log.e(TAG_LOCAL_REPO, "SecurityException during JSON file deletion: ${jsonFile.name}", e)
+                    jsonDeletedOrNotFound = false
+                } catch (e: Exception) {
+                    Log.e(TAG_LOCAL_REPO, "Error deleting JSON file: ${jsonFile.name}", e)
+                    jsonDeletedOrNotFound = false
+                }
+            } else {
+                Log.w(TAG_LOCAL_REPO, "Could not determine JSON file path to delete for ${metadata.filePath}")
+                jsonDeletedOrNotFound = false
+            }
+        }
+
+        return@withContext audioDeleted
+    }
+
+    override suspend fun deleteLocalRecordings(filePaths: List<String>): Boolean = withContext(Dispatchers.IO) {
+        var allSucceeded = true
+        Log.i(TAG_LOCAL_REPO, "Attempting to batch delete ${filePaths.size} recordings.")
+        for (filePath in filePaths) {
+            val dummyMetadata = RecordingMetadata(filePath = filePath, fileName = File(filePath).name, title = null, timestampMillis = 0, durationMillis = 0)
+            if (!deleteLocalRecording(dummyMetadata)) {
+                Log.w(TAG_LOCAL_REPO, "Batch delete failed for: $filePath")
+                allSucceeded = false
+            }
+        }
+        Log.i(TAG_LOCAL_REPO, "Batch delete operation finished. Overall success: $allSucceeded")
+        return@withContext allSucceeded
     }
 
     private fun getRecordingsDirectory(): File? {
@@ -526,7 +435,7 @@ class LocalAudioRepositoryImpl @Inject constructor(
         return recordingsDir
     }
 
-    private fun createFallbackMetadata(audioFile: File, baseName: String, title: String): RecordingMetadata {
+    private fun createFallbackMetadata(audioFile: File, baseName: String, title: String?): RecordingMetadata {
         val dateFormat = SimpleDateFormat(FILENAME_DATE_FORMAT, Locale.US)
         val timestampString = baseName.removePrefix(FILENAME_PREFIX)
         val timestampMillis = try {
@@ -552,13 +461,20 @@ class LocalAudioRepositoryImpl @Inject constructor(
             }
         }
 
+        val finalTitle = title ?: baseName.removePrefix(FILENAME_PREFIX).replace("_", " ")
+
         return RecordingMetadata(
             id = timestampMillis,
             filePath = audioFile.absolutePath,
             fileName = audioFile.name,
-            title = title,
+            title = finalTitle,
             timestampMillis = timestampMillis,
-            durationMillis = durationMillis
+            durationMillis = durationMillis,
+            remoteRecordingId = null,
+            cachedSummaryText = null,
+            cachedGlossaryItems = null,
+            cachedRecommendations = null,
+            cacheTimestampMillis = null
         )
     }
 }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/RemoteAudioRepository.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/domain/repository/RemoteAudioRepository.kt
@@ -1,11 +1,11 @@
 package edu.cit.audioscholar.domain.repository
 
 import android.net.Uri
-import edu.cit.audioscholar.data.remote.dto.AudioMetadataDto
+import edu.cit.audioscholar.data.remote.dto.*
 import kotlinx.coroutines.flow.Flow
 
 sealed class UploadResult {
-    data object Success : UploadResult()
+    data class Success(val metadata: AudioMetadataDto?) : UploadResult()
     data class Error(val message: String) : UploadResult()
     data class Progress(val percentage: Int) : UploadResult()
     data object Loading : UploadResult()
@@ -19,4 +19,8 @@ interface RemoteAudioRepository {
     ): Flow<UploadResult>
 
     fun getCloudRecordings(): Flow<Result<List<AudioMetadataDto>>>
+
+    fun getSummary(recordingId: String): Flow<Result<SummaryResponseDto>>
+
+    fun getRecommendations(recordingId: String): Flow<Result<List<RecommendationDto>>>
 }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/details/RecordingDetailsScreen.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/details/RecordingDetailsScreen.kt
@@ -1,93 +1,47 @@
 package edu.cit.audioscholar.ui.details
 
 import android.annotation.SuppressLint
-import android.content.ContentResolver
+import android.content.*
 import android.net.Uri
 import android.provider.OpenableColumns
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.*
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AttachFile
-import androidx.compose.material.icons.filled.Attachment
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.ContentCopy
-import androidx.compose.material.icons.filled.DateRange
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Error
-import androidx.compose.material.icons.filled.LinkOff
-import androidx.compose.material.icons.filled.PauseCircle
-import androidx.compose.material.icons.filled.PlayCircle
-import androidx.compose.material.icons.filled.Timer
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.*
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.*
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.*
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
+import coil.compose.AsyncImage
 import edu.cit.audioscholar.R
+import edu.cit.audioscholar.data.remote.dto.GlossaryItemDto
+import edu.cit.audioscholar.data.remote.dto.RecommendationDto
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 private fun getFileNameFromUri(contentResolver: ContentResolver, uri: Uri): String? {
@@ -107,6 +61,20 @@ private fun getFileNameFromUri(contentResolver: ContentResolver, uri: Uri): Stri
     }
     return fileName
 }
+
+private fun openUrl(context: Context, url: String) {
+    try {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        context.startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+        Log.e("UrlLauncher", "No activity found to handle URL: $url", e)
+        Toast.makeText(context, "Could not open link.", Toast.LENGTH_SHORT).show()
+    } catch (e: Exception) {
+        Log.e("UrlLauncher", "Error opening URL: $url", e)
+        Toast.makeText(context, "Error opening link.", Toast.LENGTH_SHORT).show()
+    }
+}
+
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class)
@@ -129,12 +97,10 @@ fun RecordingDetailsScreen(
                 val fileName = getFileNameFromUri(contentResolver, uri)
                 viewModel.setAttachedPowerPointFile(fileName)
             } else {
-                scope.launch { snackbarHostState.showSnackbar("File selection cancelled.") }
                 viewModel.setAttachedPowerPointFile(null)
             }
         }
     )
-
     LaunchedEffect(Unit) {
         viewModel.triggerFilePicker.collect {
             val mimeTypes = arrayOf(
@@ -150,38 +116,43 @@ fun RecordingDetailsScreen(
         }
     }
 
-    LaunchedEffect(uiState.error) {
-        uiState.error?.let { message ->
-            scope.launch {
-                snackbarHostState.showSnackbar(
-                    message = message,
-                    duration = SnackbarDuration.Short
-                )
+    LaunchedEffect(snackbarHostState) {
+        viewModel.uiState.collectLatest { state ->
+            state.error?.let { message ->
+                scope.launch {
+                    snackbarHostState.showSnackbar(
+                        message = message,
+                        duration = SnackbarDuration.Short
+                    )
+                }
                 viewModel.consumeError()
             }
-        }
-    }
-    LaunchedEffect(uiState.infoMessage) {
-        uiState.infoMessage?.let { message ->
-            scope.launch {
-                snackbarHostState.showSnackbar(
-                    message = message,
-                    duration = SnackbarDuration.Short
-                )
+            state.infoMessage?.let { message ->
+                scope.launch {
+                    snackbarHostState.showSnackbar(
+                        message = message,
+                        duration = SnackbarDuration.Short
+                    )
+                }
                 viewModel.consumeInfoMessage()
             }
+            state.textToCopy?.let { text ->
+                clipboardManager.setText(AnnotatedString(text))
+                viewModel.consumeTextToCopy()
+            }
         }
     }
-    LaunchedEffect(uiState.textToCopy) {
-        uiState.textToCopy?.let { text ->
-            clipboardManager.setText(AnnotatedString(text))
-            scope.launch {
-                snackbarHostState.showSnackbar(
-                    message = context.getString(R.string.details_copy_success_message),
-                    duration = SnackbarDuration.Short
-                )
-            }
-            viewModel.consumeTextToCopy()
+
+    LaunchedEffect(Unit) {
+        viewModel.openUrlEvent.collect { url ->
+            openUrl(context, url)
+        }
+    }
+
+    LaunchedEffect(uiState.filePath, uiState.isLoading, uiState.isDeleting) {
+        if (uiState.filePath.isEmpty() && !uiState.isLoading && !uiState.isDeleting) {
+            Log.d("RecordingDetailsScreen", "File path became empty, navigating up.")
+            navController.navigateUp()
         }
     }
 
@@ -199,294 +170,429 @@ fun RecordingDetailsScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = viewModel::requestDelete) {
-                        Icon(
-                            imageVector = Icons.Filled.Delete,
-                            contentDescription = stringResource(R.string.cd_delete_recording_action),
-                            tint = MaterialTheme.colorScheme.error
-                        )
+                    if (uiState.filePath.isNotEmpty() && !uiState.isDeleting) {
+                        IconButton(onClick = viewModel::requestDelete) {
+                            Icon(
+                                imageVector = Icons.Filled.Delete,
+                                contentDescription = stringResource(R.string.cd_delete_recording_action),
+                                tint = MaterialTheme.colorScheme.error
+                            )
+                        }
                     }
                 }
             )
         }
     ) { paddingValues ->
-        if (uiState.isLoading && !uiState.showDeleteConfirmation && uiState.filePath.isEmpty()) {
-            Box(modifier = Modifier.fillMaxSize().padding(paddingValues), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
-        } else if (uiState.filePath.isEmpty() && !uiState.isLoading) {
-            Box(modifier = Modifier.fillMaxSize().padding(paddingValues).padding(16.dp), contentAlignment = Alignment.Center) {
-                Text(stringResource(R.string.details_error_loading), color = MaterialTheme.colorScheme.error)
-            }
-        }
-        else {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-                    .verticalScroll(rememberScrollState())
-                    .padding(16.dp)
-            ) {
-                val focusRequester = remember { FocusRequester() }
-                val focusManager = LocalFocusManager.current
+        Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
 
-                Box(modifier = Modifier.fillMaxWidth()) {
-                    if (uiState.isEditingTitle) {
-                        BasicTextField(
-                            value = uiState.editableTitle,
-                            onValueChange = viewModel::onTitleChanged,
-                            textStyle = MaterialTheme.typography.headlineSmall.copy(
-                                fontWeight = FontWeight.Bold,
-                                color = LocalContentColor.current
-                            ),
-                            keyboardOptions = KeyboardOptions(
-                                capitalization = KeyboardCapitalization.Sentences,
-                                imeAction = ImeAction.Done
-                            ),
-                            keyboardActions = KeyboardActions(
-                                onDone = {
-                                    viewModel.onTitleSaveRequested()
-                                    focusManager.clearFocus()
-                                }
-                            ),
-                            singleLine = true,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .focusRequester(focusRequester)
-                                .onFocusChanged { focusState ->
-                                }
-                        )
-                        LaunchedEffect(Unit) {
-                            focusRequester.requestFocus()
-                        }
-                    } else {
+            when {
+                uiState.isLoading && uiState.filePath.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                        Log.d("DetailsScreen", "Showing initial loading indicator")
+                    }
+                }
+
+                uiState.filePath.isEmpty() && !uiState.isLoading && !uiState.isDeleting -> {
+                    Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
                         Text(
-                            text = uiState.title,
-                            style = MaterialTheme.typography.headlineSmall,
-                            fontWeight = FontWeight.Bold,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable(
-                                    onClick = viewModel::onTitleEditRequested,
+                            stringResource(R.string.details_error_loading),
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyLarge,
+                            textAlign = TextAlign.Center
+                        )
+                        Log.d("DetailsScreen", "Showing error loading details")
+                    }
+                }
+
+                else -> {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState())
+                            .padding(16.dp)
+                    ) {
+                        val focusRequester = remember { FocusRequester() }
+                        val focusManager = LocalFocusManager.current
+
+                        Box(modifier = Modifier.fillMaxWidth()) {
+                            if (uiState.isEditingTitle) {
+                                BasicTextField(
+                                    value = uiState.editableTitle,
+                                    onValueChange = viewModel::onTitleChanged,
+                                    textStyle = MaterialTheme.typography.headlineSmall.copy(
+                                        fontWeight = FontWeight.Bold,
+                                        color = LocalContentColor.current
+                                    ),
+                                    keyboardOptions = KeyboardOptions(
+                                        capitalization = KeyboardCapitalization.Sentences,
+                                        imeAction = ImeAction.Done
+                                    ),
+                                    keyboardActions = KeyboardActions(
+                                        onDone = {
+                                            viewModel.onTitleSaveRequested()
+                                            focusManager.clearFocus()
+                                        }
+                                    ),
+                                    singleLine = true,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .focusRequester(focusRequester)
+                                        .onFocusChanged { }
                                 )
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(4.dp))
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(Icons.Filled.DateRange, contentDescription = null, modifier = Modifier.size(16.dp), tint = LocalContentColor.current.copy(alpha = 0.7f))
-                    Text(
-                        text = uiState.dateCreated,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = LocalContentColor.current.copy(alpha = 0.7f)
-                    )
-                    Text("•", style = MaterialTheme.typography.bodyMedium, color = LocalContentColor.current.copy(alpha = 0.7f))
-                    Icon(Icons.Filled.Timer, contentDescription = null, modifier = Modifier.size(16.dp), tint = LocalContentColor.current.copy(alpha = 0.7f))
-                    Text(
-                        text = uiState.durationFormatted,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = LocalContentColor.current.copy(alpha = 0.7f)
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-                HorizontalDivider()
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Text(stringResource(R.string.details_playback_title), style = MaterialTheme.typography.titleMedium)
-                Spacer(modifier = Modifier.height(8.dp))
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    IconButton(onClick = viewModel::onPlayPauseToggle) {
-                        Icon(
-                            imageVector = if (uiState.isPlaying) Icons.Filled.PauseCircle else Icons.Filled.PlayCircle,
-                            contentDescription = if (uiState.isPlaying) stringResource(R.string.cd_pause_playback) else stringResource(R.string.cd_play_playback),
-                            modifier = Modifier.size(48.dp),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Slider(
-                        value = uiState.playbackProgress,
-                        onValueChange = viewModel::onSeek,
-                        modifier = Modifier.weight(1f)
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = "${uiState.currentPositionFormatted} / ${uiState.durationFormatted}",
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-                HorizontalDivider()
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Text(stringResource(R.string.details_summary_title), style = MaterialTheme.typography.titleMedium)
-                Spacer(modifier = Modifier.height(8.dp))
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-                ) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text(
-                                text = stringResource(R.string.details_summary_status_label),
-                                style = MaterialTheme.typography.labelMedium,
-                                fontWeight = FontWeight.Bold
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            when (uiState.summaryStatus) {
-                                SummaryStatus.IDLE -> {
-                                    Text("Not started", style = MaterialTheme.typography.labelMedium, color = LocalContentColor.current.copy(alpha = 0.7f))
+                                LaunchedEffect(Unit) {
+                                    focusRequester.requestFocus()
                                 }
-                                SummaryStatus.PROCESSING -> {
-                                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
-                                    Spacer(modifier = Modifier.width(4.dp))
-                                    Text("Processing...", style = MaterialTheme.typography.labelMedium, color = LocalContentColor.current.copy(alpha = 0.7f))
-                                }
-                                SummaryStatus.READY -> {
-                                    Icon(Icons.Filled.CheckCircle, contentDescription = stringResource(R.string.cd_summary_ready), tint = Color(0xFF2E7D32), modifier = Modifier.size(16.dp))
-                                    Spacer(modifier = Modifier.width(4.dp))
-                                    Text("Ready", style = MaterialTheme.typography.labelMedium, color = Color(0xFF2E7D32))
-                                }
-                                SummaryStatus.FAILED -> {
-                                    Icon(Icons.Filled.Error, contentDescription = stringResource(R.string.cd_summary_failed), tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(16.dp))
-                                    Spacer(modifier = Modifier.width(4.dp))
-                                    Text("Failed", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.error)
+                            } else {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(
+                                        text = uiState.title,
+                                        style = MaterialTheme.typography.headlineSmall,
+                                        fontWeight = FontWeight.Bold,
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                    if (!uiState.isProcessing && !uiState.isDeleting) {
+                                        IconButton(
+                                            onClick = viewModel::onTitleEditRequested,
+                                            modifier = Modifier.size(36.dp)
+                                        ) {
+                                            Icon(
+                                                Icons.Filled.Edit,
+                                                contentDescription = "Edit title",
+                                                modifier = Modifier.size(20.dp),
+                                                tint = LocalContentColor.current.copy(alpha = 0.7f)
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         }
+
+                        Spacer(modifier = Modifier.height(4.dp))
+
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(Icons.Filled.DateRange, contentDescription = null, modifier = Modifier.size(16.dp), tint = LocalContentColor.current.copy(alpha = 0.7f))
+                            Text(
+                                text = uiState.dateCreated,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = LocalContentColor.current.copy(alpha = 0.7f)
+                            )
+                            Text("•", style = MaterialTheme.typography.bodyMedium, color = LocalContentColor.current.copy(alpha = 0.7f))
+                            Icon(Icons.Filled.Timer, contentDescription = null, modifier = Modifier.size(16.dp), tint = LocalContentColor.current.copy(alpha = 0.7f))
+                            Text(
+                                text = uiState.durationFormatted,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = LocalContentColor.current.copy(alpha = 0.7f)
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(16.dp))
+                        HorizontalDivider()
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        Text(stringResource(R.string.details_playback_title), style = MaterialTheme.typography.titleMedium)
                         Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = uiState.summaryText.ifEmpty { stringResource(R.string.details_summary_placeholder) },
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = if (uiState.summaryText.isEmpty() && uiState.summaryStatus != SummaryStatus.PROCESSING) LocalContentColor.current.copy(alpha = 0.5f) else LocalContentColor.current
-                        )
-                        if (uiState.summaryStatus == SummaryStatus.READY) {
-                            Spacer(modifier = Modifier.height(12.dp))
-                            Button(
-                                onClick = viewModel::onCopySummaryAndNotes,
-                                modifier = Modifier.align(Alignment.End)
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            val isPlaybackEnabled = !uiState.isProcessing && !uiState.isDeleting
+                            IconButton(
+                                onClick = viewModel::onPlayPauseToggle,
+                                enabled = isPlaybackEnabled
                             ) {
                                 Icon(
-                                    Icons.Filled.ContentCopy,
-                                    contentDescription = stringResource(R.string.cd_copy_summary_notes),
+                                    imageVector = if (uiState.isPlaying) Icons.Filled.PauseCircle else Icons.Filled.PlayCircle,
+                                    contentDescription = if (uiState.isPlaying) stringResource(R.string.cd_pause_playback) else stringResource(R.string.cd_play_playback),
+                                    modifier = Modifier.size(48.dp),
+                                )
+                            }
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Slider(
+                                value = uiState.playbackProgress,
+                                onValueChange = viewModel::onSeek,
+                                modifier = Modifier.weight(1f),
+                                enabled = isPlaybackEnabled
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = "${uiState.currentPositionFormatted} / ${uiState.durationFormatted}",
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(16.dp))
+                        HorizontalDivider()
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        if (uiState.remoteRecordingId == null && !uiState.isProcessing) {
+                            Button(
+                                onClick = viewModel::onProcessRecordingClicked,
+                                modifier = Modifier.fillMaxWidth(),
+                                enabled = !uiState.isProcessing
+                            ) {
+                                Icon(
+                                    Icons.Filled.CloudUpload,
+                                    contentDescription = null,
                                     modifier = Modifier.size(ButtonDefaults.IconSize)
                                 )
                                 Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-                                Text(stringResource(R.string.details_summary_copy_button))
+                                Text(stringResource(R.string.details_process_recording_button))
+                            }
+                            Spacer(modifier = Modifier.height(16.dp))
+                            HorizontalDivider()
+                            Spacer(modifier = Modifier.height(16.dp))
+                        }
+
+                        if (uiState.remoteRecordingId != null || uiState.summaryStatus == SummaryStatus.PROCESSING) {
+                            Text(stringResource(R.string.details_summary_title), style = MaterialTheme.typography.titleMedium)
+                            Spacer(modifier = Modifier.height(8.dp))
+
+                            if (uiState.summaryStatus != SummaryStatus.IDLE) {
+                                Card(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+                                ) {
+                                    Column(modifier = Modifier.padding(16.dp)) {
+                                        Row(verticalAlignment = Alignment.CenterVertically) {
+                                            Text(
+                                                text = stringResource(R.string.details_summary_status_label),
+                                                style = MaterialTheme.typography.labelMedium,
+                                                fontWeight = FontWeight.Bold
+                                            )
+                                            Spacer(modifier = Modifier.width(8.dp))
+                                            when (uiState.summaryStatus) {
+                                                SummaryStatus.PROCESSING -> {
+                                                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                                                    Spacer(modifier = Modifier.width(4.dp))
+                                                    Text("Processing...", style = MaterialTheme.typography.labelMedium, color = LocalContentColor.current.copy(alpha = 0.7f))
+                                                }
+                                                SummaryStatus.READY -> {
+                                                    Icon(Icons.Filled.CheckCircle, contentDescription = stringResource(R.string.cd_summary_ready), tint = Color(0xFF2E7D32), modifier = Modifier.size(16.dp))
+                                                    Spacer(modifier = Modifier.width(4.dp))
+                                                    Text("Ready", style = MaterialTheme.typography.labelMedium, color = Color(0xFF2E7D32))
+                                                }
+                                                SummaryStatus.FAILED -> {
+                                                    Icon(Icons.Filled.Error, contentDescription = stringResource(R.string.cd_summary_failed), tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(16.dp))
+                                                    Spacer(modifier = Modifier.width(4.dp))
+                                                    Text("Failed", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.error)
+                                                }
+                                                SummaryStatus.IDLE -> {}
+                                            }
+                                        }
+                                        Spacer(modifier = Modifier.height(8.dp))
+
+                                        if (uiState.summaryStatus == SummaryStatus.READY) {
+                                            Text(
+                                                text = uiState.summaryText.ifBlank { stringResource(R.string.details_summary_placeholder) },
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = if (uiState.summaryText.isBlank()) LocalContentColor.current.copy(alpha = 0.5f) else LocalContentColor.current
+                                            )
+                                            if (uiState.summaryText.isNotEmpty() || uiState.glossaryItems.isNotEmpty()) {
+                                                Spacer(modifier = Modifier.height(12.dp))
+                                                Button(
+                                                    onClick = viewModel::onCopySummaryAndNotes,
+                                                    modifier = Modifier.align(Alignment.End),
+                                                    enabled = !uiState.isProcessing
+                                                ) {
+                                                    Icon(
+                                                        Icons.Filled.ContentCopy,
+                                                        contentDescription = stringResource(R.string.cd_copy_summary_notes),
+                                                        modifier = Modifier.size(ButtonDefaults.IconSize)
+                                                    )
+                                                    Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                                                    Text(stringResource(R.string.details_summary_copy_button))
+                                                }
+                                            }
+                                        } else if (uiState.summaryStatus == SummaryStatus.FAILED) {
+                                            Text(
+                                                text = uiState.error ?: "Failed to load summary.",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = MaterialTheme.colorScheme.error
+                                            )
+                                        }
+                                    }
+                                }
+                                Spacer(modifier = Modifier.height(16.dp))
+                                HorizontalDivider()
+                                Spacer(modifier = Modifier.height(16.dp))
                             }
                         }
+
+                        if (uiState.summaryStatus == SummaryStatus.READY && uiState.glossaryItems.isNotEmpty()) {
+                            Text(stringResource(R.string.details_ai_notes_title), style = MaterialTheme.typography.titleMedium)
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Card(
+                                modifier = Modifier.fillMaxWidth(),
+                                elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+                                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+                            ) {
+                                Column(modifier = Modifier.padding(16.dp)) {
+                                    uiState.glossaryItems.forEachIndexed { index, item ->
+                                        GlossaryItemView(item = item)
+                                        if (index < uiState.glossaryItems.lastIndex) {
+                                            Spacer(modifier = Modifier.height(8.dp))
+                                        }
+                                    }
+                                }
+                            }
+                            Spacer(modifier = Modifier.height(16.dp))
+                            HorizontalDivider()
+                            Spacer(modifier = Modifier.height(16.dp))
+                        }
+
+                        Text(stringResource(R.string.details_powerpoint_title), style = MaterialTheme.typography.titleMedium)
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            val currentAttachment = uiState.attachedPowerPoint
+                            if (currentAttachment != null) {
+                                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f, fill = false).padding(end = 8.dp)) {
+                                    Icon(Icons.Filled.Attachment, contentDescription = null, modifier = Modifier.size(20.dp))
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text(
+                                        text = currentAttachment,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                }
+                            } else {
+                                Text(
+                                    text = stringResource(R.string.details_powerpoint_none_attached),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = LocalContentColor.current.copy(alpha = 0.7f),
+                                    modifier = Modifier.weight(1f, fill = false).padding(end = 8.dp)
+                                )
+                            }
+                            Button(
+                                onClick = {
+                                    if (currentAttachment == null) {
+                                        viewModel.requestAttachPowerPoint()
+                                    } else {
+                                        viewModel.detachPowerPoint()
+                                    }
+                                },
+                                enabled = !uiState.isProcessing && !uiState.isDeleting
+                            ) {
+                                val icon = if (currentAttachment == null) Icons.Filled.AttachFile else Icons.Filled.LinkOff
+                                val textRes = if (currentAttachment == null) R.string.details_powerpoint_attach_button else R.string.details_powerpoint_detach_button
+                                Icon(icon, contentDescription = null, modifier = Modifier.size(ButtonDefaults.IconSize))
+                                Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                                Text(stringResource(textRes))
+                            }
+                        }
+
+                        if (uiState.remoteRecordingId != null || uiState.recommendationsStatus == RecommendationsStatus.LOADING) {
+                            Spacer(modifier = Modifier.height(16.dp))
+                            HorizontalDivider()
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            Text(stringResource(R.string.details_youtube_title), style = MaterialTheme.typography.titleMedium)
+                            Spacer(modifier = Modifier.height(8.dp))
+
+                            when(uiState.recommendationsStatus) {
+                                RecommendationsStatus.LOADING -> {
+                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                                        Spacer(modifier = Modifier.width(8.dp))
+                                        Text(
+                                            text = "Loading recommendations...",
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = LocalContentColor.current.copy(alpha = 0.7f)
+                                        )
+                                    }
+                                }
+                                RecommendationsStatus.READY -> {
+                                    if (uiState.youtubeRecommendations.isNotEmpty()) {
+                                        LazyRow(
+                                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                            contentPadding = PaddingValues(horizontal = 4.dp)
+                                        ) {
+                                            items(items = uiState.youtubeRecommendations, key = { it.recommendationId ?: it.videoId ?: it.hashCode() }) { video ->
+                                                YouTubeRecommendationCard(video = video, onClick = { viewModel.onWatchYouTubeVideo(video) })
+                                            }
+                                        }
+                                    } else {
+                                        Text(
+                                            text = "No relevant videos found.",
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = LocalContentColor.current.copy(alpha = 0.7f)
+                                        )
+                                    }
+                                }
+                                RecommendationsStatus.FAILED -> {
+                                    Text(
+                                        text = if (uiState.error?.contains("Recommendations Error") == true) uiState.error!! else "Failed to load recommendations.",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.error
+                                    )
+                                }
+                                RecommendationsStatus.IDLE -> {}
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(24.dp))
                     }
                 }
+            }
 
-                if (uiState.summaryStatus == SummaryStatus.READY && uiState.aiNotesText.isNotEmpty()) {
-                    Spacer(modifier = Modifier.height(16.dp))
-                    HorizontalDivider()
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    Text(stringResource(R.string.details_ai_notes_title), style = MaterialTheme.typography.titleMedium)
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Card(
-                        modifier = Modifier.fillMaxWidth(),
-                        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
-                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
-                    ) {
-                        Text(
-                            text = uiState.aiNotesText,
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier.padding(16.dp)
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-                HorizontalDivider()
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Text(stringResource(R.string.details_powerpoint_title), style = MaterialTheme.typography.titleMedium)
-                Spacer(modifier = Modifier.height(8.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween
+            if (uiState.isProcessing) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clickable(enabled = false, onClick = {}),
+                    contentAlignment = Alignment.Center
                 ) {
-                    val currentAttachment = uiState.attachedPowerPoint
-                    if (currentAttachment != null) {
-                        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f, fill = false).padding(end = 8.dp)) {
-                            Icon(Icons.Filled.Attachment, contentDescription = null, modifier = Modifier.size(20.dp))
-                            Spacer(modifier = Modifier.width(8.dp))
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        if (uiState.uploadProgressPercent != null) {
+                            LinearProgressIndicator(
+                                progress = { (uiState.uploadProgressPercent ?: 0) / 100f },
+                                modifier = Modifier.width(150.dp)
+                            )
                             Text(
-                                text = currentAttachment,
-                                style = MaterialTheme.typography.bodyMedium,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
+                                text = "Uploading ${uiState.uploadProgressPercent}%",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = Color.White
+                            )
+                        } else {
+                            CircularProgressIndicator(color = Color.White)
+                            Text(
+                                text = when {
+                                    uiState.summaryStatus == SummaryStatus.PROCESSING -> stringResource(R.string.details_processing_data)
+                                    uiState.recommendationsStatus == RecommendationsStatus.LOADING -> "Fetching recommendations..."
+                                    else -> "Processing..."
+                                },
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = Color.White
                             )
                         }
-                    } else {
-                        Text(
-                            text = stringResource(R.string.details_powerpoint_none_attached),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = LocalContentColor.current.copy(alpha = 0.7f),
-                            modifier = Modifier.weight(1f, fill = false).padding(end = 8.dp)
-                        )
-                    }
-                    Button(onClick = {
-                        if (currentAttachment == null) {
-                            viewModel.requestAttachPowerPoint()
-                        } else {
-                            viewModel.detachPowerPoint()
-                        }
-                    }) {
-                        val icon = if (currentAttachment == null) Icons.Filled.AttachFile else Icons.Filled.LinkOff
-                        val textRes = if (currentAttachment == null) R.string.details_powerpoint_attach_button else R.string.details_powerpoint_detach_button
-                        Icon(icon, contentDescription = null, modifier = Modifier.size(ButtonDefaults.IconSize))
-                        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-                        Text(stringResource(textRes))
                     }
                 }
-
-                if (uiState.summaryStatus == SummaryStatus.READY && uiState.youtubeRecommendations.isNotEmpty()) {
-                    Spacer(modifier = Modifier.height(16.dp))
-                    HorizontalDivider()
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    Text(stringResource(R.string.details_youtube_title), style = MaterialTheme.typography.titleMedium)
-                    Spacer(modifier = Modifier.height(8.dp))
-                    LazyRow(
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        contentPadding = PaddingValues(horizontal = 4.dp)
-                    ) {
-                        items(items = uiState.youtubeRecommendations, key = { it.id }) { video ->
-                            YouTubeRecommendationCard(video = video)
-                        }
-                    }
-                }
-                Spacer(modifier = Modifier.height(24.dp))
             }
         }
 
         if (uiState.showDeleteConfirmation) {
             AlertDialog(
-                onDismissRequest = viewModel::cancelDelete,
+                onDismissRequest = { if (!uiState.isDeleting) viewModel.cancelDelete() },
                 title = { Text(stringResource(R.string.dialog_delete_title)) },
                 text = { Text(stringResource(R.string.dialog_delete_message_details, uiState.title)) },
                 confirmButton = {
                     Button(
-                        onClick = {
-                            viewModel.confirmDelete()
-                            navController.navigateUp()
-                        },
-                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                        onClick = viewModel::confirmDelete,
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+                        enabled = !uiState.isDeleting
                     ) {
-                        if (uiState.isLoading && uiState.showDeleteConfirmation) {
+                        if (uiState.isDeleting) {
                             CircularProgressIndicator(
                                 modifier = Modifier.size(24.dp),
                                 color = MaterialTheme.colorScheme.onError,
@@ -498,39 +604,72 @@ fun RecordingDetailsScreen(
                     }
                 },
                 dismissButton = {
-                    TextButton(onClick = viewModel::cancelDelete) {
+                    TextButton(
+                        onClick = viewModel::cancelDelete,
+                        enabled = !uiState.isDeleting
+                    ) {
                         Text(stringResource(R.string.dialog_action_cancel))
                     }
                 }
             )
         }
+
+    }
+}
+
+
+@Composable
+fun GlossaryItemView(item: GlossaryItemDto) {
+    Column {
+        Text(
+            buildAnnotatedString {
+                withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                    append(item.term ?: "Unknown Term")
+                }
+                append(": ")
+                append(item.definition ?: "No definition available.")
+            },
+            style = MaterialTheme.typography.bodyMedium
+        )
     }
 }
 
 @Composable
 fun YouTubeRecommendationCard(
-    video: MockYouTubeVideo
+    video: RecommendationDto,
+    onClick: () -> Unit
 ) {
     Card(
-        modifier = Modifier.width(180.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        modifier = Modifier
+            .width(180.dp)
+            .height(IntrinsicSize.Min)
+            .clickable(onClick = onClick),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Column {
-            Image(
-                painter = painterResource(id = video.thumbnailUrl),
-                contentDescription = video.title,
+            AsyncImage(
+                model = video.thumbnailUrl,
+                contentDescription = video.title ?: "YouTube video thumbnail",
                 modifier = Modifier
                     .height(100.dp)
-                    .fillMaxWidth(),
-                contentScale = ContentScale.Crop
+                    .fillMaxWidth()
+                    .clip(MaterialTheme.shapes.medium),
+                contentScale = ContentScale.Crop,
+                placeholder = painterResource(id = R.drawable.ic_youtubeplaceholder_quantum),
+                error = painterResource(id = R.drawable.ic_youtubeplaceholder_quantum)
             )
-            Column(modifier = Modifier.padding(12.dp)) {
+            Column(modifier = Modifier
+                .padding(12.dp)
+                .height(60.dp)
+                .fillMaxWidth(),
+                verticalArrangement = Arrangement.Top
+            ) {
                 Text(
-                    text = video.title,
+                    text = video.title ?: "No Title",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.SemiBold,
                     maxLines = 3,
-                    minLines = 2
+                    overflow = TextOverflow.Ellipsis
                 )
             }
         }

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/details/RecordingDetailsUiState.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/details/RecordingDetailsUiState.kt
@@ -1,19 +1,17 @@
 package edu.cit.audioscholar.ui.details
 
 import androidx.compose.runtime.Stable
-
-data class MockYouTubeVideo(
-    val id: String,
-    val thumbnailUrl: Int,
-    val title: String
-)
+import edu.cit.audioscholar.data.remote.dto.GlossaryItemDto
+import edu.cit.audioscholar.data.remote.dto.RecommendationDto
 
 enum class SummaryStatus { IDLE, PROCESSING, READY, FAILED }
+enum class RecommendationsStatus { IDLE, LOADING, READY, FAILED }
 
 
 @Stable
 data class RecordingDetailsUiState(
     val isLoading: Boolean = true,
+    val isDeleting: Boolean = false,
     val error: String? = null,
     val infoMessage: String? = null,
 
@@ -22,6 +20,7 @@ data class RecordingDetailsUiState(
     val durationMillis: Long = 0L,
     val durationFormatted: String = "00:00",
     val filePath: String = "",
+    val remoteRecordingId: String? = null,
 
     val isEditingTitle: Boolean = false,
     val editableTitle: String = "",
@@ -33,13 +32,21 @@ data class RecordingDetailsUiState(
 
     val summaryStatus: SummaryStatus = SummaryStatus.IDLE,
     val summaryText: String = "",
-    val aiNotesText: String = "",
+    val glossaryItems: List<GlossaryItemDto> = emptyList(),
+
+    val recommendationsStatus: RecommendationsStatus = RecommendationsStatus.IDLE,
+    val youtubeRecommendations: List<RecommendationDto> = emptyList(),
 
     val attachedPowerPoint: String? = null,
 
-    val youtubeRecommendations: List<MockYouTubeVideo> = emptyList(),
-
     val showDeleteConfirmation: Boolean = false,
 
-    val textToCopy: String? = null
-)
+    val textToCopy: String? = null,
+
+    val uploadProgressPercent: Int? = null
+) {
+    val isProcessing: Boolean
+        get() = uploadProgressPercent != null ||
+                summaryStatus == SummaryStatus.PROCESSING ||
+                recommendationsStatus == RecommendationsStatus.LOADING
+}

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/details/RecordingDetailsViewModel.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/details/RecordingDetailsViewModel.kt
@@ -1,28 +1,22 @@
 package edu.cit.audioscholar.ui.details
 
+import android.app.Application
 import android.net.Uri
 import android.util.Log
-import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import androidx.core.net.toUri
+import androidx.lifecycle.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import edu.cit.audioscholar.R
 import edu.cit.audioscholar.data.local.model.RecordingMetadata
-import edu.cit.audioscholar.domain.repository.LocalAudioRepository
+import edu.cit.audioscholar.data.remote.dto.RecommendationDto
+import edu.cit.audioscholar.data.remote.dto.SummaryResponseDto
+import edu.cit.audioscholar.domain.repository.*
 import edu.cit.audioscholar.service.PlaybackManager
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import retrofit2.HttpException
 import java.io.File
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -44,11 +38,17 @@ private fun formatTimestampMillis(timestampMillis: Long): String {
     return format.format(date)
 }
 
+private const val POLLING_INTERVAL_MS = 3000L
+private const val POLLING_TIMEOUT_MS = 25000L
+private const val CACHE_VALIDITY_MS = 24 * 60 * 60 * 1000
+
 @HiltViewModel
 class RecordingDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val localAudioRepository: LocalAudioRepository,
-    private val playbackManager: PlaybackManager
+    private val playbackManager: PlaybackManager,
+    private val remoteAudioRepository: RemoteAudioRepository,
+    private val application: Application
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(RecordingDetailsUiState())
@@ -57,20 +57,29 @@ class RecordingDetailsViewModel @Inject constructor(
     private val _triggerFilePicker = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val triggerFilePicker: SharedFlow<Unit> = _triggerFilePicker.asSharedFlow()
 
+    private val _openUrlEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val openUrlEvent: SharedFlow<String> = _openUrlEvent.asSharedFlow()
+
     private val recordingId: String = savedStateHandle.get<String>("recordingId") ?: ""
     private val decodedFilePath: String = Uri.decode(recordingId)
+
+    private var pollingJob: Job? = null
+    private var currentMetadata: RecordingMetadata? = null
 
 
     init {
         Log.d("DetailsViewModel", "Initializing for recordingId: $recordingId, decodedPath: $decodedFilePath")
         if (decodedFilePath.isNotEmpty()) {
             loadRecordingDetails()
-            loadMockRecommendations()
-            fetchMockSummaryAndNotes()
             observePlaybackState()
         } else {
-            _uiState.update { it.copy(isLoading = false, error = "Recording ID not found.") }
+            _uiState.update { it.copy(isLoading = false, error = application.getString(R.string.error_unexpected_details_view)) }
         }
+    }
+
+    private fun isCacheValid(cacheTimestampMillis: Long?): Boolean {
+        if (cacheTimestampMillis == null) return false
+        return (System.currentTimeMillis() - cacheTimestampMillis) < CACHE_VALIDITY_MS
     }
 
     private fun loadRecordingDetails() {
@@ -80,16 +89,28 @@ class RecordingDetailsViewModel @Inject constructor(
             localAudioRepository.getRecordingMetadata(decodedFilePath)
                 .catch { e ->
                     Log.e("DetailsViewModel", "Error loading details for $decodedFilePath", e)
+                    val errorMsg = when (e) {
+                        is IOException -> application.getString(R.string.error_local_storage_issue)
+                        else -> application.getString(R.string.error_unexpected_details_view)
+                    }
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            error = "Failed to load recording details: ${e.message}"
+                            error = errorMsg
                         )
                     }
                 }
                 .collect { result ->
                     result.onSuccess { metadata ->
+                        currentMetadata = metadata
                         val currentTitle = metadata.title ?: metadata.fileName
+                        val remoteId = metadata.remoteRecordingId
+                        val cacheTimestamp = metadata.cacheTimestampMillis
+                        val isSummaryCacheValid = isCacheValid(cacheTimestamp) && metadata.cachedSummaryText != null
+                        val areRecommendationsCacheValid = isCacheValid(cacheTimestamp) && metadata.cachedRecommendations != null
+
+                        Log.d("DetailsViewModel", "Metadata loaded. RemoteId: $remoteId, CacheTime: $cacheTimestamp, SummaryCacheValid: $isSummaryCacheValid, RecsCacheValid: $areRecommendationsCacheValid")
+
                         _uiState.update {
                             it.copy(
                                 isLoading = false,
@@ -99,16 +120,46 @@ class RecordingDetailsViewModel @Inject constructor(
                                 durationMillis = metadata.durationMillis,
                                 durationFormatted = formatDurationMillis(metadata.durationMillis),
                                 filePath = metadata.filePath,
-                                error = null
+                                remoteRecordingId = remoteId,
+                                error = null,
+                                summaryStatus = when {
+                                    isSummaryCacheValid -> SummaryStatus.READY
+                                    remoteId != null -> SummaryStatus.PROCESSING
+                                    else -> SummaryStatus.IDLE
+                                },
+                                recommendationsStatus = when {
+                                    areRecommendationsCacheValid -> RecommendationsStatus.READY
+                                    remoteId != null -> RecommendationsStatus.LOADING
+                                    else -> RecommendationsStatus.IDLE
+                                },
+                                summaryText = if (isSummaryCacheValid) metadata.cachedSummaryText ?: "" else "",
+                                glossaryItems = if (isSummaryCacheValid) metadata.cachedGlossaryItems ?: emptyList() else emptyList(),
+                                youtubeRecommendations = if (areRecommendationsCacheValid) metadata.cachedRecommendations ?: emptyList() else emptyList()
                             )
                         }
                         playbackManager.preparePlayer(metadata.filePath)
+
+                        if (remoteId != null && (!isSummaryCacheValid || !areRecommendationsCacheValid)) {
+                            Log.d("DetailsViewModel", "Remote ID found ($remoteId) and cache is invalid/missing, starting polling.")
+                            startPollingForSummaryAndRecommendations(remoteId, !isSummaryCacheValid, !areRecommendationsCacheValid)
+                        } else if (remoteId == null) {
+                            Log.d("DetailsViewModel", "No remote ID found, waiting for 'Process' button.")
+                            if (!isSummaryCacheValid) _uiState.update { it.copy(summaryStatus = SummaryStatus.IDLE) }
+                            if (!areRecommendationsCacheValid) _uiState.update { it.copy(recommendationsStatus = RecommendationsStatus.IDLE) }
+                        } else {
+                            Log.d("DetailsViewModel", "Remote ID found ($remoteId) but cache is valid. No polling needed initially.")
+                        }
+
                     }.onFailure { e ->
                         Log.e("DetailsViewModel", "Failed result loading details for $decodedFilePath", e)
+                        val errorMsg = when (e) {
+                            is IOException -> application.getString(R.string.error_local_storage_issue)
+                            else -> application.getString(R.string.error_unexpected_details_view)
+                        }
                         _uiState.update {
                             it.copy(
                                 isLoading = false,
-                                error = "Failed to load recording details: ${e.message}"
+                                error = errorMsg
                             )
                         }
                     }
@@ -130,7 +181,7 @@ class RecordingDetailsViewModel @Inject constructor(
                         durationFormatted = formatDurationMillis(currentDuration),
                         currentPositionFormatted = formatDurationMillis(playbackState.currentPositionMs),
                         playbackProgress = progress,
-                        error = playbackState.error ?: if(playbackState.isPlaying || !currentState.isPlaying) null else currentState.error
+                        error = playbackState.error ?: currentState.error
                     )
                 }
                 if(playbackState.error != null) {
@@ -139,47 +190,305 @@ class RecordingDetailsViewModel @Inject constructor(
             }.launchIn(viewModelScope)
     }
 
+    private fun startPollingForSummaryAndRecommendations(remoteId: String, pollForSummary: Boolean, pollForRecommendations: Boolean) {
+        if (!pollForSummary && !pollForRecommendations) {
+            Log.d("DetailsViewModel", "Polling requested but both summary and recommendations cache are valid.")
+            return
+        }
 
-    private fun loadMockRecommendations() {
-        viewModelScope.launch {
-            delay(500)
+        pollingJob?.cancel()
+        pollingJob = viewModelScope.launch {
+            Log.d("DetailsViewModel", "Polling started for remoteId: $remoteId. PollSummary: $pollForSummary, PollRecs: $pollForRecommendations")
+
             _uiState.update {
                 it.copy(
-                    youtubeRecommendations = listOf(
-                        MockYouTubeVideo("vid1", R.drawable.ic_youtubeplaceholder_quantum, "Introduction to Quantum Mechanics"),
-                        MockYouTubeVideo("vid2", R.drawable.ic_youtubeplaceholder_superposition, "Superposition Explained Simply"),
-                        MockYouTubeVideo("vid3", R.drawable.ic_youtubeplaceholder_entanglement, "The Mystery of Entanglement")
-                    )
+                    summaryStatus = if (pollForSummary) SummaryStatus.PROCESSING else it.summaryStatus,
+                    recommendationsStatus = if (pollForRecommendations) RecommendationsStatus.LOADING else it.recommendationsStatus,
+                    error = null
                 )
+            }
+
+            var summaryFetchSuccess = !pollForSummary
+
+            if (pollForSummary) {
+                summaryFetchSuccess = pollForData(
+                    timeoutMs = POLLING_TIMEOUT_MS,
+                    intervalMs = POLLING_INTERVAL_MS,
+                    fetchAction = { remoteAudioRepository.getSummary(remoteId) },
+                    onSuccess = { summaryDto ->
+                        Log.i("DetailsViewModel", "Summary polling successful.")
+                        updateCacheAndUi(summary = summaryDto)
+                    },
+                    onFailure = { errorMsg ->
+                        Log.e("DetailsViewModel", "Summary polling failed: $errorMsg")
+                        _uiState.update { it.copy(summaryStatus = SummaryStatus.FAILED, error = errorMsg) }
+                    },
+                    onTimeout = {
+                        Log.w("DetailsViewModel", "Summary polling timed out.")
+                        _uiState.update { it.copy(summaryStatus = SummaryStatus.FAILED, error = application.getString(R.string.error_processing_timeout)) }
+                    }
+                )
+            }
+
+            if (summaryFetchSuccess && pollForRecommendations) {
+                _uiState.update { it.copy(recommendationsStatus = RecommendationsStatus.LOADING, error = null) }
+                pollForData(
+                    timeoutMs = POLLING_TIMEOUT_MS,
+                    intervalMs = POLLING_INTERVAL_MS,
+                    fetchAction = { remoteAudioRepository.getRecommendations(remoteId) },
+                    onSuccess = { recommendations ->
+                        Log.i("DetailsViewModel", "Recommendations polling successful.")
+                        updateCacheAndUi(recommendations = recommendations)
+                    },
+                    onFailure = { errorMsg ->
+                        Log.e("DetailsViewModel", "Recommendations polling failed: $errorMsg")
+                        _uiState.update { it.copy(recommendationsStatus = RecommendationsStatus.FAILED, error = errorMsg) }
+                    },
+                    onTimeout = {
+                        Log.w("DetailsViewModel", "Recommendations polling timed out.")
+                        _uiState.update { it.copy(recommendationsStatus = RecommendationsStatus.FAILED, error = application.getString(R.string.error_processing_timeout)) }
+                    }
+                )
+            } else if (!summaryFetchSuccess && pollForRecommendations) {
+                Log.w("DetailsViewModel", "Skipping recommendations polling because summary failed.")
+                if (_uiState.value.error == null) {
+                    _uiState.update { it.copy(recommendationsStatus = RecommendationsStatus.FAILED, error = application.getString(R.string.error_recommendations_fetch_failed)) }
+                } else {
+                    _uiState.update { it.copy(recommendationsStatus = RecommendationsStatus.FAILED) }
+                }
+            }
+
+            if (_uiState.value.summaryStatus != SummaryStatus.PROCESSING && _uiState.value.recommendationsStatus != RecommendationsStatus.LOADING) {
+                Log.d("DetailsViewModel", "Polling finished.")
             }
         }
     }
 
-    private fun fetchMockSummaryAndNotes() {
+    private fun updateCacheAndUi(
+        summary: SummaryResponseDto? = null,
+        recommendations: List<RecommendationDto>? = null
+    ) {
         viewModelScope.launch {
-            _uiState.update { it.copy(summaryStatus = SummaryStatus.PROCESSING, summaryText = "AI summary is being generated...", aiNotesText = "") }
-            delay(3000)
-            val success = Math.random() > 0.3
-            if (success) {
-                _uiState.update { it.copy(
-                    summaryStatus = SummaryStatus.READY,
-                    summaryText = "This lecture covered the main topics of quantum physics, including superposition and entanglement. Key formulas were discussed, and potential applications in computing were highlighted.",
-                    aiNotesText = """
-                        - Quantum Superposition: Particles exist in multiple states at once.
-                        - Entanglement: Linked particles share the same fate, regardless of distance.
-                        - Key Formula: Schrödinger equation (Hψ = Eψ).
-                        - Applications: Quantum computing, cryptography.
-                    """.trimIndent()
-                ) }
+            val meta = currentMetadata ?: return@launch
+
+            val updatedMetadata = meta.copy(
+                cachedSummaryText = summary?.formattedSummaryText ?: meta.cachedSummaryText,
+                cachedGlossaryItems = summary?.glossary ?: meta.cachedGlossaryItems,
+                cachedRecommendations = recommendations ?: meta.cachedRecommendations,
+                cacheTimestampMillis = System.currentTimeMillis()
+            )
+
+            val saved = localAudioRepository.saveMetadata(updatedMetadata)
+            if (saved) {
+                currentMetadata = updatedMetadata
+                Log.i("DetailsViewModel", "Successfully saved updated metadata cache.")
+                _uiState.update {
+                    it.copy(
+                        summaryStatus = if (summary != null || it.summaryStatus == SummaryStatus.READY) SummaryStatus.READY else it.summaryStatus,
+                        summaryText = updatedMetadata.cachedSummaryText ?: it.summaryText,
+                        glossaryItems = updatedMetadata.cachedGlossaryItems ?: it.glossaryItems,
+                        recommendationsStatus = if (recommendations != null || it.recommendationsStatus == RecommendationsStatus.READY) RecommendationsStatus.READY else it.recommendationsStatus,
+                        youtubeRecommendations = updatedMetadata.cachedRecommendations ?: it.youtubeRecommendations
+                    )
+                }
             } else {
-                _uiState.update { it.copy(
-                    summaryStatus = SummaryStatus.FAILED,
-                    summaryText = "Failed to generate summary. Please try again later.",
-                    aiNotesText = ""
-                ) }
+                Log.e("DetailsViewModel", "Failed to save updated metadata cache.")
+                _uiState.update { it.copy(error = application.getString(R.string.error_metadata_update_failed)) }
             }
         }
     }
+
+    private suspend fun <T> pollForData(
+        timeoutMs: Long,
+        intervalMs: Long,
+        fetchAction: () -> Flow<Result<T>>,
+        onSuccess: (T) -> Unit,
+        onFailure: (String) -> Unit,
+        onTimeout: () -> Unit
+    ): Boolean {
+        return withTimeoutOrNull(timeoutMs) {
+            var lastError: Throwable? = null
+
+            while (isActive) {
+                var attemptSuccessful = false
+                var shouldRetry = false
+                var mappedErrorMessage: String? = null
+
+                try {
+                    fetchAction()
+                        .catch { e ->
+                            Log.e("DetailsViewModelPolling", "Exception during fetch flow collection", e)
+                            lastError = e
+                            mappedErrorMessage = mapErrorToUserFriendlyMessage(e)
+                            shouldRetry = e is IOException
+                        }
+                        .collect { result ->
+                            result.onSuccess { data ->
+                                Log.d("DetailsViewModelPolling", "Polling attempt successful.")
+                                attemptSuccessful = true
+                                onSuccess(data)
+                            }.onFailure { e ->
+                                lastError = e
+                                if (e is HttpException && e.code() == 404) {
+                                    Log.d("DetailsViewModelPolling", "Received 404, resource not ready yet. Will retry...")
+                                    shouldRetry = true
+                                } else {
+                                    Log.w("DetailsViewModelPolling", "Polling attempt failed with non-retryable error: ${e.message}")
+                                    mappedErrorMessage = mapErrorToUserFriendlyMessage(e)
+                                    shouldRetry = false
+                                }
+                            }
+                        }
+                } catch (e: CancellationException) {
+                    Log.d("DetailsViewModelPolling", "Polling cancelled.")
+                    throw e
+                } catch (e: Exception) {
+                    Log.e("DetailsViewModelPolling", "Unexpected exception during fetch attempt: ${e.message}", e)
+                    lastError = e
+                    mappedErrorMessage = mapErrorToUserFriendlyMessage(e)
+                    shouldRetry = false
+                }
+
+                if (attemptSuccessful) {
+                    return@withTimeoutOrNull true
+                }
+
+                if (shouldRetry) {
+                    Log.d("DetailsViewModelPolling", "Retrying polling after ${intervalMs}ms delay...")
+                    delay(intervalMs)
+                } else {
+                    onFailure(mappedErrorMessage ?: application.getString(R.string.error_unexpected_details_view))
+                    return@withTimeoutOrNull false
+                }
+            }
+            false
+        } ?: run {
+            Log.w("DetailsViewModelPolling", "Polling timed out after ${timeoutMs}ms.")
+            onTimeout()
+            false
+        }
+    }
+
+    fun onProcessRecordingClicked() {
+        Log.d("DetailsViewModel", "Process Recording button clicked for: ${uiState.value.filePath}")
+        val currentState = uiState.value
+        val meta = currentMetadata
+
+        if (meta == null || meta.remoteRecordingId != null || meta.filePath.isEmpty() || currentState.isProcessing) {
+            Log.w("DetailsViewModel", "Process Recording clicked but state is invalid. RemoteId: ${meta?.remoteRecordingId}, Path: ${meta?.filePath}, Processing: ${currentState.isProcessing}")
+            _uiState.update { it.copy(error = "Recording cannot be processed or is already processed/processing.") }
+            return
+        }
+
+        _uiState.update { it.copy(
+            summaryStatus = SummaryStatus.PROCESSING,
+            recommendationsStatus = RecommendationsStatus.LOADING,
+            uploadProgressPercent = 0,
+            error = null
+        ) }
+
+        val fileToUpload = File(meta.filePath)
+        if (!fileToUpload.exists() || !fileToUpload.canRead()) {
+            Log.e("DetailsViewModel", "File does not exist or cannot be read: ${meta.filePath}")
+            _uiState.update { it.copy(
+                summaryStatus = SummaryStatus.FAILED,
+                recommendationsStatus = RecommendationsStatus.FAILED,
+                error = application.getString(R.string.error_local_storage_issue),
+                uploadProgressPercent = null
+            ) }
+            return
+        }
+
+        val fileUri = fileToUpload.toUri()
+        val titleToUpload = (if (currentState.isEditingTitle) currentState.editableTitle else meta.title)
+            ?.takeIf { it.isNotBlank() && it != fileToUpload.name }
+
+        viewModelScope.launch {
+            Log.d("DetailsViewModel", "Starting upload process via repository for URI: $fileUri, Title: $titleToUpload")
+            remoteAudioRepository.uploadAudioFile(fileUri, titleToUpload, null)
+                .catch { e ->
+                    Log.e("DetailsViewModel", "Exception during upload flow collection", e)
+                    _uiState.update { it.copy(
+                        uploadProgressPercent = null,
+                        summaryStatus = SummaryStatus.FAILED,
+                        recommendationsStatus = RecommendationsStatus.FAILED,
+                        error = mapErrorToUserFriendlyMessage(e))
+                    }
+                }
+                .collect { result ->
+                    when (result) {
+                        is UploadResult.Loading -> {}
+                        is UploadResult.Progress -> {
+                            _uiState.update { it.copy(uploadProgressPercent = result.percentage) }
+                        }
+                        is UploadResult.Success -> {
+                            val remoteMetadataDto = result.metadata
+                            _uiState.update { it.copy(
+                                uploadProgressPercent = null,
+                                summaryStatus = SummaryStatus.PROCESSING,
+                                recommendationsStatus = RecommendationsStatus.LOADING
+                            ) }
+
+                            if (remoteMetadataDto?.recordingId != null) {
+                                val newRemoteId = remoteMetadataDto.recordingId
+                                Log.i("DetailsViewModel", "Upload successful. Received remote recordingId: $newRemoteId")
+
+                                val updatedMetaWithId = meta.copy(remoteRecordingId = newRemoteId)
+                                val idSaveSuccess = localAudioRepository.saveMetadata(updatedMetaWithId)
+
+                                if (idSaveSuccess) {
+                                    currentMetadata = updatedMetaWithId
+                                    Log.i("DetailsViewModel", "Successfully saved remoteRecordingId to local metadata.")
+                                    _uiState.update { it.copy(remoteRecordingId = newRemoteId) }
+                                    startPollingForSummaryAndRecommendations(newRemoteId, pollForSummary = true, pollForRecommendations = true)
+                                } else {
+                                    Log.e("DetailsViewModel", "Failed to save remoteRecordingId to local metadata.")
+                                    _uiState.update { it.copy(
+                                        summaryStatus = SummaryStatus.FAILED,
+                                        recommendationsStatus = RecommendationsStatus.FAILED,
+                                        error = application.getString(R.string.error_metadata_update_failed)
+                                    ) }
+                                }
+                            } else {
+                                Log.e("DetailsViewModel", "Upload successful but recordingId was missing in the response.")
+                                _uiState.update { it.copy(
+                                    summaryStatus = SummaryStatus.FAILED,
+                                    recommendationsStatus = RecommendationsStatus.FAILED,
+                                    error = application.getString(R.string.error_server_generic)
+                                ) }
+                            }
+                        }
+                        is UploadResult.Error -> {
+                            Log.e("DetailsViewModel", "Upload failed: ${result.message}")
+                            val userFriendlyError = result.message?.let {
+                                application.getString(R.string.error_upload_failed_detailed, it)
+                            } ?: application.getString(R.string.error_upload_failed_generic)
+
+                            _uiState.update { it.copy(
+                                uploadProgressPercent = null,
+                                summaryStatus = SummaryStatus.FAILED,
+                                recommendationsStatus = RecommendationsStatus.FAILED,
+                                error = userFriendlyError )
+                            }
+                        }
+                    }
+                }
+        }
+    }
+
+    private fun mapErrorToUserFriendlyMessage(e: Throwable): String {
+        return when (e) {
+            is IOException -> application.getString(R.string.error_network_connection_generic)
+            is HttpException -> {
+                when (e.code()) {
+                    in 500..599 -> application.getString(R.string.error_server_generic)
+                    else -> application.getString(R.string.error_unexpected_details_view) + " (Code: ${e.code()})"
+                }
+            }
+            else -> application.getString(R.string.error_unexpected_details_view)
+        }
+    }
+
 
     fun onPlayPauseToggle() {
         val currentState = _uiState.value
@@ -224,12 +533,16 @@ class RecordingDetailsViewModel @Inject constructor(
 
     fun onCopySummaryAndNotes() {
         val state = _uiState.value
-        if (state.summaryStatus == SummaryStatus.READY) {
-            val combinedText = "Summary:\n${state.summaryText}\n\nAI Notes:\n${state.aiNotesText}"
+        if (state.summaryStatus == SummaryStatus.READY && (state.summaryText.isNotEmpty() || state.glossaryItems.isNotEmpty())) {
+            val summaryPart = "Summary:\n${state.summaryText.ifBlank { "Not available" }}\n\n"
+            val notesPart = "AI Notes (Glossary):\n" +
+                    state.glossaryItems.joinToString("\n") { "- ${it.term ?: "Term N/A"}: ${it.definition ?: "Definition N/A"}" }.ifEmpty { "Not available" }
+
+            val combinedText = summaryPart + notesPart
             Log.d("DetailsViewModel", "Copy Summary & Notes clicked. Text prepared.")
-            _uiState.update { it.copy(textToCopy = combinedText, infoMessage = "Summary and notes ready to copy.") }
+            _uiState.update { it.copy(textToCopy = combinedText, infoMessage = "Summary & Notes copied!") }
         } else {
-            Log.w("DetailsViewModel", "Copy attempt failed: Summary not ready.")
+            Log.w("DetailsViewModel", "Copy attempt failed: Summary not ready or empty.")
             _uiState.update { it.copy(error = "Summary and notes are not available to copy.") }
         }
     }
@@ -250,7 +563,7 @@ class RecordingDetailsViewModel @Inject constructor(
             Log.d("DetailsViewModel", "Setting attached PowerPoint: $fileName")
             _uiState.update { it.copy(attachedPowerPoint = fileName, infoMessage = "PowerPoint attached: $fileName") }
         } else {
-            _uiState.update { it.copy(error = "Failed to select PowerPoint file.") }
+            _uiState.update { it.copy(infoMessage = "PowerPoint selection cancelled.") }
         }
     }
 
@@ -259,9 +572,18 @@ class RecordingDetailsViewModel @Inject constructor(
         _uiState.update { it.copy(attachedPowerPoint = null, infoMessage = "PowerPoint detached.") }
     }
 
-    fun onWatchYouTubeVideo(video: MockYouTubeVideo) {
-        Log.d("DetailsViewModel", "Watch YouTube clicked: ${video.title}")
-        _uiState.update { it.copy(infoMessage = "Mock: Opening video ${video.title}") }
+    fun onWatchYouTubeVideo(video: RecommendationDto) {
+        val videoId = video.videoId
+        if (videoId != null) {
+            Log.d("DetailsViewModel", "Watch YouTube clicked: ${video.title} (ID: $videoId)")
+            val url = "https://www.youtube.com/watch?v=$videoId"
+            viewModelScope.launch {
+                _openUrlEvent.emit(url)
+            }
+        } else {
+            Log.w("DetailsViewModel", "Watch YouTube clicked, but videoId is null for: ${video.title}")
+            _uiState.update { it.copy(error = "Cannot open video: Missing video ID.") }
+        }
     }
 
     fun requestDelete() {
@@ -273,41 +595,36 @@ class RecordingDetailsViewModel @Inject constructor(
     }
 
     fun confirmDelete() {
+        pollingJob?.cancel()
         playbackManager.pause()
-        _uiState.update { it.copy(showDeleteConfirmation = false, isLoading = true) }
+        _uiState.update { it.copy(showDeleteConfirmation = false, isDeleting = true) }
         viewModelScope.launch {
-            if (decodedFilePath.isEmpty()) {
-                Log.e("DetailsViewModel", "Cannot delete: File path is empty.")
-                _uiState.update { it.copy(isLoading = false, error = "Cannot delete recording: file path unknown.") }
+            val metaToDelete = currentMetadata
+            if (metaToDelete == null || metaToDelete.filePath.isEmpty()) {
+                Log.e("DetailsViewModel", "Cannot delete: Metadata or file path is missing.")
+                _uiState.update { it.copy(isDeleting = false, error = "Cannot delete recording: file path unknown.") }
                 return@launch
             }
 
-            val metadataToDelete = RecordingMetadata(
-                id = 0,
-                filePath = decodedFilePath,
-                fileName = File(decodedFilePath).name,
-                title = _uiState.value.title,
-                timestampMillis = 0,
-                durationMillis = _uiState.value.durationMillis
-            )
+            val localDeleteSuccess = localAudioRepository.deleteLocalRecording(metaToDelete)
 
-            val success = localAudioRepository.deleteLocalRecording(metadataToDelete)
-
-            if (success) {
-                Log.d("DetailsViewModel", "Deletion successful for: $decodedFilePath")
+            if (localDeleteSuccess) {
+                Log.d("DetailsViewModel", "Deletion successful for: ${metaToDelete.filePath}")
                 playbackManager.releasePlayer()
+                currentMetadata = null
+                _uiState.update { it.copy(filePath = "", isDeleting = false, infoMessage = "Recording deleted.") }
             } else {
-                Log.e("DetailsViewModel", "Error deleting file: $decodedFilePath")
+                Log.e("DetailsViewModel", "Error deleting file: ${metaToDelete.filePath}")
                 _uiState.update {
                     it.copy(
-                        isLoading = false,
+                        isDeleting = false,
                         error = "Failed to delete recording."
                     )
                 }
             }
-            _uiState.update { it.copy(isLoading = false) }
         }
     }
+
 
     fun consumeError() {
         _uiState.update { it.copy(error = null) }
@@ -325,39 +642,39 @@ class RecordingDetailsViewModel @Inject constructor(
         _uiState.update { it.copy(editableTitle = newTitle) }
     }
 
-    fun onTitleEditCancelled() {
-        _uiState.update { it.copy(isEditingTitle = false, editableTitle = it.title) }
-        Log.d("DetailsViewModel", "Title edit cancelled.")
-    }
-
     fun onTitleSaveRequested() {
         val state = _uiState.value
+        val meta = currentMetadata
         val newTitle = state.editableTitle.trim()
 
-        if (newTitle.isEmpty()) {
-            Log.w("DetailsViewModel", "Save requested with empty title. Reverting.")
-            _uiState.update { it.copy(isEditingTitle = false, editableTitle = it.title, error = "Title cannot be empty.") }
+        if (meta == null) {
+            Log.e("DetailsViewModel", "Cannot save title: Current metadata is null.")
+            _uiState.update { it.copy(isEditingTitle = false, error = application.getString(R.string.error_metadata_update_failed)) }
             return
         }
 
-        if (newTitle != state.title) {
-            Log.d("DetailsViewModel", "Saving new title: $newTitle for path: ${state.filePath}")
-            _uiState.update { it.copy(isEditingTitle = false, title = newTitle) }
+        if (newTitle.isEmpty()) {
+            Log.w("DetailsViewModel", "Save requested with empty title. Reverting.")
+            _uiState.update { it.copy(isEditingTitle = false, editableTitle = meta.title ?: "", error = "Title cannot be empty.") }
+            return
+        }
+
+        if (newTitle != meta.title) {
+            Log.d("DetailsViewModel", "Saving new title: $newTitle for path: ${meta.filePath}")
+            _uiState.update { it.copy(isEditingTitle = false, title = newTitle, isLoading = true) }
 
             viewModelScope.launch {
-                try {
-                    val success = localAudioRepository.updateRecordingTitle(state.filePath, newTitle)
+                val success = localAudioRepository.updateRecordingTitle(meta.filePath, newTitle)
 
-                    if (!success) {
-                        Log.e("DetailsViewModel", "Failed to update title in repository for ${state.filePath}")
-                        _uiState.update { it.copy(title = state.title, error = "Failed to save title.") }
-                    } else {
-                        Log.d("DetailsViewModel", "Title updated successfully in repository.")
-                        _uiState.update { it.copy(infoMessage = "Title updated.") }
+                if (!success) {
+                    Log.e("DetailsViewModel", "Failed to update title in repository for ${meta.filePath}")
+                    _uiState.update { it.copy(isLoading = false, title = meta.title ?: "", error = application.getString(R.string.error_metadata_update_failed)) }
+                } else {
+                    Log.d("DetailsViewModel", "Title updated successfully in repository.")
+                    localAudioRepository.getRecordingMetadata(meta.filePath).firstOrNull()?.getOrNull()?.let { updatedMeta ->
+                        currentMetadata = updatedMeta
                     }
-                } catch (e: Exception) {
-                    Log.e("DetailsViewModel", "Error saving title for ${state.filePath}", e)
-                    _uiState.update { it.copy(title = state.title, error = "Error saving title: ${e.message}") }
+                    _uiState.update { it.copy(isLoading = false, infoMessage = "Title updated.") }
                 }
             }
         } else {
@@ -368,7 +685,8 @@ class RecordingDetailsViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
+        pollingJob?.cancel()
         playbackManager.releasePlayer()
-        Log.d("DetailsViewModel", "ViewModel cleared, player released.")
+        Log.d("DetailsViewModel", "ViewModel cleared, polling stopped, player released.")
     }
 }

--- a/frontend_mobile/AudioScholar/app/src/main/res/values/strings.xml
+++ b/frontend_mobile/AudioScholar/app/src/main/res/values/strings.xml
@@ -41,6 +41,23 @@
     <string name="error_unexpected_saving">An unexpected error occurred while saving.</string>
     <string name="error_service_start">Could not start recording service.</string>
 
+    <string name="details_process_recording_button">Process Recording</string>
+    <string name="details_processing_data">Processing data…</string>
+    <string name="details_summary_placeholder">Summary will appear here once processed.</string>
+    <string name="details_error_loading">Could not load recording details.</string>
+    <string name="details_copy_success_message">Copied to clipboard</string>
+
+    <string name="error_network_connection_generic">Could not connect. Please check your internet connection.</string>
+    <string name="error_server_generic">Could not reach the server. Please try again later.</string>
+    <string name="error_processing_timeout">Processing took too long. Please try again later.</string>
+    <string name="error_summary_fetch_failed">Failed to get summary. Please try again.</string>
+    <string name="error_recommendations_fetch_failed">Failed to get recommendations. Please try again.</string>
+    <string name="error_upload_failed_generic">Upload failed. Please try again.</string>
+    <string name="error_upload_failed_detailed">Upload failed: %1$s</string>
+    <string name="error_local_storage_issue">Cannot process: File not found or unreadable.</string>
+    <string name="error_metadata_update_failed">Failed to update local recording details.</string>
+    <string name="error_unexpected_details_view">An unexpected error occurred.</string>
+
     <string name="edit_profile_displayname_label">Display Name</string>
     <string name="edit_profile_displayname_placeholder">How your name appears publicly</string>
     <string name="button_save">Save Changes</string>
@@ -90,9 +107,6 @@
 
     <string name="details_summary_copy_button">Copy Summary &amp; Notes</string>
     <string name="details_ai_notes_title">AI Notes</string>
-    <string name="details_copy_success_message">Copied to clipboard</string>
-    <string name="details_summary_placeholder">Summary will appear here when ready.</string>
-    <string name="details_error_loading">Could not load recording details.</string>
     <string name="cd_copy_summary_notes">Copy summary and notes</string>
     <string name="cd_ai_notes_section">AI generated notes section</string>
     <string name="cd_powerpoint_section">PowerPoint attachment section</string>


### PR DESCRIPTION
This pull request implements the integration of the recording details screen with the backend API. It includes changes to the `GlossaryItemDto`, `AudioMetadataDto`, `LocalAudioRepository`, `RecordingMetadata`, `SummaryResponseDto`, `RecommendationDto`, `RemoteAudioRepository`, `ApiService`, and `RecordingDetailsUiState` files. The changes allow for retrieving and displaying the summary, glossary items, and recommendations for a recording.