### PR TITLE
fix: Update notification icons and URLs in the app

### DIFF
--- a/frontend_mobile/AudioScholar/app/src/main/AndroidManifest.xml
+++ b/frontend_mobile/AudioScholar/app/src/main/AndroidManifest.xml
@@ -62,7 +62,7 @@
         </service>
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"
-            android:resource="@drawable/ic_mic" />
+            android:resource="@mipmap/ic_audioscholar" />
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
             android:value="@string/default_notification_channel_id"

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/di/NetworkModule.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/di/NetworkModule.kt
@@ -70,7 +70,7 @@ class TimeoutInterceptor @Inject constructor() : Interceptor {
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
 
-    private const val PRIMARY_BASE_URL = "https://mastodon-balanced-randomly.ngrok-free.app/"
+    private const val PRIMARY_BASE_URL = "https://it342-g3-audioscholar-onrender-com.onrender.com/"
     private const val FALLBACK_URL_1 = "https://mastodon-balanced-randomly.ngrok-free.app/"
     private const val FALLBACK_URL_2 = "http://192.168.254.104:8080/"
 

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/service/FcmService.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/service/FcmService.kt
@@ -28,6 +28,7 @@ const val RECORDING_ID_EXTRA = "RECORDING_ID"
 const val SUMMARY_ID_EXTRA = "SUMMARY_ID"
 const val UPLOAD_SCREEN_VALUE = "UPLOAD_SCREEN"
 const val RECORDING_DETAIL_DESTINATION = "RECORDING_DETAIL"
+const val LIBRARY_CLOUD_DESTINATION = "LIBRARY_CLOUD"
 
 const val GENERAL_NOTIFICATION_CHANNEL_ID = "GENERAL_NOTIFICATIONS"
 const val PROCESSING_COMPLETE_CHANNEL_ID = "PROCESSING_COMPLETE"
@@ -126,7 +127,7 @@ class FcmService : FirebaseMessagingService() {
     private fun sendProcessingCompleteNotification(recordingId: String) {
         val intent = Intent(this, MainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            putExtra(NAVIGATE_TO_EXTRA, RECORDING_DETAIL_DESTINATION)
+            putExtra(NAVIGATE_TO_EXTRA, LIBRARY_CLOUD_DESTINATION)
             putExtra(RECORDING_ID_EXTRA, recordingId)
         }
 
@@ -140,7 +141,7 @@ class FcmService : FirebaseMessagingService() {
         )
 
         val notificationBuilder = NotificationCompat.Builder(this, PROCESSING_COMPLETE_CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_mic)
+            .setSmallIcon(R.mipmap.ic_audioscholar)
             .setContentTitle("Processing Complete")
             .setContentText("Your audio recording is ready.")
             .setAutoCancel(true)
@@ -170,7 +171,7 @@ class FcmService : FirebaseMessagingService() {
         )
 
         val notificationBuilder = NotificationCompat.Builder(this, GENERAL_NOTIFICATION_CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_mic)
+            .setSmallIcon(R.mipmap.ic_audioscholar)
             .setContentTitle(title ?: "AudioScholar")
             .setContentText(messageBody ?: "New notification")
             .setAutoCancel(true)

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/service/RecordingService.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/service/RecordingService.kt
@@ -629,7 +629,7 @@ class RecordingService : Service() {
         val builder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
             .setContentTitle(getString(R.string.notification_title_recording))
             .setContentText(contentText)
-            .setSmallIcon(R.drawable.ic_mic)
+            .setSmallIcon(R.mipmap.ic_audioscholar)
             .setLargeIcon(largeIconBitmap)
             .setContentIntent(pendingIntent)
             .setOngoing(true)

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/about/AboutScreen.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/about/AboutScreen.kt
@@ -211,7 +211,7 @@ fun AboutScreen(
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
                 TextButton(
-                    onClick = { uriHandler.openUri(context.getString(R.string.about_privacy_policy_url)) },
+                    onClick = { uriHandler.openUri(context.getString(R.string.settings_url_privacy_policy)) },
                     colors = ButtonDefaults.textButtonColors(
                         contentColor = MaterialTheme.colorScheme.primary
                     )
@@ -219,7 +219,7 @@ fun AboutScreen(
                     Text(stringResource(id = R.string.about_link_privacy_policy))
                 }
                 TextButton(
-                    onClick = { uriHandler.openUri(context.getString(R.string.about_terms_of_use_url)) },
+                    onClick = { uriHandler.openUri(context.getString(R.string.settings_url_terms_service)) },
                     colors = ButtonDefaults.textButtonColors(
                         contentColor = MaterialTheme.colorScheme.primary
                     )

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/main/MainActivity.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/main/MainActivity.kt
@@ -38,6 +38,7 @@ import edu.cit.audioscholar.service.NAVIGATE_TO_EXTRA
 import edu.cit.audioscholar.service.RECORDING_DETAIL_DESTINATION
 import edu.cit.audioscholar.service.RECORDING_ID_EXTRA
 import edu.cit.audioscholar.service.UPLOAD_SCREEN_VALUE
+import edu.cit.audioscholar.service.LIBRARY_CLOUD_DESTINATION
 import edu.cit.audioscholar.ui.about.AboutScreen
 import edu.cit.audioscholar.ui.auth.*
 import edu.cit.audioscholar.ui.details.RecordingDetailsScreen
@@ -330,6 +331,14 @@ class MainActivity : ComponentActivity() {
             UPLOAD_SCREEN_VALUE -> {
                 Log.w("MainActivity", "[handleNavigationIntent] Intent requested navigation to removed Upload screen. Ignoring.")
                 intent.removeExtra(NAVIGATE_TO_EXTRA)
+            }
+            LIBRARY_CLOUD_DESTINATION -> {
+                Log.i("MainActivity", "[handleNavigationIntent] Intent requests navigation to Library (Cloud). Navigating...")
+                navController.navigate(Screen.Library.route) {
+                    launchSingleTop = true
+                }
+                intent.removeExtra(NAVIGATE_TO_EXTRA)
+                intent.removeExtra(RECORDING_ID_EXTRA)
             }
             null -> {
                 Log.d("MainActivity", "[handleNavigationIntent] No specific navigation target in intent extras (NAVIGATE_TO_EXTRA is null)." )

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/settings/SettingsScreen.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/settings/SettingsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
@@ -50,6 +51,8 @@ import edu.cit.audioscholar.domain.model.QualitySetting
 import edu.cit.audioscholar.ui.main.Screen
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import edu.cit.audioscholar.ui.settings.SyncMode
+import edu.cit.audioscholar.ui.settings.SyncFrequency
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -59,12 +62,17 @@ fun SettingsScreen(
     scope: CoroutineScope,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
-    LocalContext.current
+    val context = LocalContext.current
     val showThemeDialog = remember { mutableStateOf(false) }
     val showQualityDialog = remember { mutableStateOf(false) }
+    val showSyncModeDialog = remember { mutableStateOf(false) }
+    val showSyncFrequencyDialog = remember { mutableStateOf(false) }
+    val uriHandler = LocalUriHandler.current
 
     val selectedTheme by viewModel.selectedTheme.collectAsState()
     val selectedQuality by viewModel.selectedQuality.collectAsState()
+    val selectedSyncMode by viewModel.selectedSyncMode.collectAsState()
+    val selectedSyncFrequency by viewModel.selectedSyncFrequency.collectAsState()
 
     if (showThemeDialog.value) {
         SelectionDialog(
@@ -85,6 +93,28 @@ fun SettingsScreen(
             onSelectionChanged = { viewModel.updateQuality(it) },
             onDismissRequest = { showQualityDialog.value = false },
             optionLabel = { quality -> stringResource(id = quality.labelResId) }
+        )
+    }
+
+    if (showSyncModeDialog.value) {
+        SelectionDialog(
+            title = stringResource(R.string.settings_dialog_title_sync_mode),
+            options = SyncMode.entries,
+            currentSelection = selectedSyncMode,
+            onSelectionChanged = { viewModel.updateSyncMode(it) },
+            onDismissRequest = { showSyncModeDialog.value = false },
+            optionLabel = { mode -> stringResource(id = mode.labelResId) }
+        )
+    }
+
+    if (showSyncFrequencyDialog.value) {
+        SelectionDialog(
+            title = stringResource(R.string.settings_dialog_title_sync_frequency),
+            options = SyncFrequency.entries,
+            currentSelection = selectedSyncFrequency,
+            onSelectionChanged = { viewModel.updateSyncFrequency(it) },
+            onDismissRequest = { showSyncFrequencyDialog.value = false },
+            optionLabel = { frequency -> stringResource(id = frequency.labelResId) }
         )
     }
 
@@ -110,13 +140,13 @@ fun SettingsScreen(
             SettingsSectionHeader(title = stringResource(R.string.settings_section_cloud_sync))
             SettingsItemRow(
                 title = stringResource(R.string.settings_item_sync_mode),
-                subtitle = "Automatic",
-                onClick = { }
+                subtitle = stringResource(id = selectedSyncMode.labelResId),
+                onClick = { showSyncModeDialog.value = true }
             )
             SettingsItemRow(
                 title = stringResource(R.string.settings_item_sync_frequency),
-                subtitle = "Daily",
-                onClick = { }
+                subtitle = stringResource(id = selectedSyncFrequency.labelResId),
+                onClick = { showSyncFrequencyDialog.value = true }
             )
 
             HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp))
@@ -142,15 +172,15 @@ fun SettingsScreen(
             SettingsSectionHeader(title = stringResource(R.string.settings_section_support))
             SettingsItemRow(
                 title = stringResource(R.string.settings_item_help_center),
-                onClick = { }
+                onClick = { uriHandler.openUri(context.getString(R.string.settings_url_help_center)) }
             )
             SettingsItemRow(
                 title = stringResource(R.string.settings_item_privacy_policy),
-                onClick = { }
+                onClick = { uriHandler.openUri(context.getString(R.string.settings_url_privacy_policy)) }
             )
             SettingsItemRow(
                 title = stringResource(R.string.settings_item_terms_service),
-                onClick = { }
+                onClick = { uriHandler.openUri(context.getString(R.string.settings_url_terms_service)) }
             )
 
             HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp))

--- a/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/settings/SettingsViewModel.kt
+++ b/frontend_mobile/AudioScholar/app/src/main/java/edu/cit/audioscholar/ui/settings/SettingsViewModel.kt
@@ -13,6 +13,18 @@ import javax.inject.Named
 import edu.cit.audioscholar.di.PreferencesModule
 import edu.cit.audioscholar.domain.model.QualitySetting
 
+enum class SyncMode(@StringRes val labelResId: Int) {
+    Automatic(R.string.settings_sync_mode_automatic),
+    Manual(R.string.settings_sync_mode_manual),
+    WifiOnly(R.string.settings_sync_mode_wifi_only)
+}
+
+enum class SyncFrequency(@StringRes val labelResId: Int) {
+    Daily(R.string.settings_sync_freq_daily),
+    Weekly(R.string.settings_sync_freq_weekly),
+    Monthly(R.string.settings_sync_freq_monthly)
+}
+
 enum class ThemeSetting(@StringRes val labelResId: Int) {
     Light(R.string.settings_theme_light),
     Dark(R.string.settings_theme_dark),
@@ -26,6 +38,8 @@ class SettingsViewModel @Inject constructor(
 
     companion object {
         const val PREF_KEY_THEME = "pref_theme"
+        const val PREF_KEY_SYNC_MODE = "pref_sync_mode"
+        const val PREF_KEY_SYNC_FREQUENCY = "pref_sync_frequency"
     }
 
     private val _selectedTheme = MutableStateFlow(ThemeSetting.System)
@@ -33,6 +47,12 @@ class SettingsViewModel @Inject constructor(
 
     private val _selectedQuality = MutableStateFlow(QualitySetting.Medium)
     val selectedQuality: StateFlow<QualitySetting> = _selectedQuality.asStateFlow()
+
+    private val _selectedSyncMode = MutableStateFlow(SyncMode.Automatic)
+    val selectedSyncMode: StateFlow<SyncMode> = _selectedSyncMode.asStateFlow()
+
+    private val _selectedSyncFrequency = MutableStateFlow(SyncFrequency.Daily)
+    val selectedSyncFrequency: StateFlow<SyncFrequency> = _selectedSyncFrequency.asStateFlow()
 
 
     init {
@@ -47,6 +67,14 @@ class SettingsViewModel @Inject constructor(
         val savedQualityName = prefs.getString(QualitySetting.PREF_KEY, QualitySetting.DEFAULT)
         _selectedQuality.value = QualitySetting.values().firstOrNull { it.name == savedQualityName }
             ?: QualitySetting.Medium
+
+        val savedSyncModeName = prefs.getString(PREF_KEY_SYNC_MODE, SyncMode.Automatic.name)
+        _selectedSyncMode.value = SyncMode.values().firstOrNull { it.name == savedSyncModeName }
+            ?: SyncMode.Automatic
+
+        val savedSyncFrequencyName = prefs.getString(PREF_KEY_SYNC_FREQUENCY, SyncFrequency.Daily.name)
+        _selectedSyncFrequency.value = SyncFrequency.values().firstOrNull { it.name == savedSyncFrequencyName }
+            ?: SyncFrequency.Daily
     }
 
     fun updateTheme(theme: ThemeSetting) {
@@ -61,6 +89,22 @@ class SettingsViewModel @Inject constructor(
         _selectedQuality.value = quality
         with(prefs.edit()) {
             putString(QualitySetting.PREF_KEY, quality.name)
+            apply()
+        }
+    }
+
+    fun updateSyncMode(mode: SyncMode) {
+        _selectedSyncMode.value = mode
+        with(prefs.edit()) {
+            putString(PREF_KEY_SYNC_MODE, mode.name)
+            apply()
+        }
+    }
+
+    fun updateSyncFrequency(frequency: SyncFrequency) {
+        _selectedSyncFrequency.value = frequency
+        with(prefs.edit()) {
+            putString(PREF_KEY_SYNC_FREQUENCY, frequency.name)
             apply()
         }
     }

--- a/frontend_mobile/AudioScholar/app/src/main/res/values/strings.xml
+++ b/frontend_mobile/AudioScholar/app/src/main/res/values/strings.xml
@@ -290,8 +290,6 @@
     <string name="about_contact_email_subject">AudioScholar Mobile App Support</string>
     <string name="about_contact_email_body">Please describe your issue or feedback here:\n\n</string>
     <string name="about_contact_email_address">audioscholar.support@example.com</string>
-    <string name="about_privacy_policy_url">https://audioscholar.example.com/privacy</string>
-    <string name="about_terms_of_use_url">https://audioscholar.example.com/terms</string>
     <string name="cd_about_app_logo">AudioScholar App Logo</string>
 
     <string name="onboarding_skip">Skip</string>
@@ -337,5 +335,18 @@
     <string name="info_cloud_recording_deleted">Cloud recording deleted.</string>
     <string name="info_local_recording_deleted">Local recording deleted.</string>
     <string name="error_delete_failed_local">Failed to delete the local recording file.</string>
+
+    <string name="settings_sync_mode_automatic">Automatic</string>
+    <string name="settings_sync_mode_manual">Manual</string>
+    <string name="settings_sync_mode_wifi_only">Wi-Fi Only</string>
+    <string name="settings_sync_freq_daily">Daily</string>
+    <string name="settings_sync_freq_weekly">Weekly</string>
+    <string name="settings_sync_freq_monthly">Monthly</string>
+    <string name="settings_dialog_title_sync_mode">Select Sync Mode</string>
+    <string name="settings_dialog_title_sync_frequency">Select Sync Frequency</string>
+
+    <string name="settings_url_help_center">https://rentry.co/it342-audioscholar-privacy-policy</string>
+    <string name="settings_url_privacy_policy">https://rentry.co/it342-audioscholar-privacy</string>
+    <string name="settings_url_terms_service">https://rentry.co/it342-audioscholar-termsofservice</string>
 
 </resources>


### PR DESCRIPTION
- Changed notification icons from `ic_mic` to `ic_audioscholar` in multiple services for consistency.
- Updated the primary base URL in `NetworkModule` to the new production endpoint.
- Modified navigation destinations in `FcmService` and `MainActivity` to use the new `LIBRARY_CLOUD_DESTINATION`.
- Enhanced the `AboutScreen` to link to the updated privacy policy and terms of service URLs.
- Introduced sync mode and frequency settings in `SettingsScreen` with corresponding ViewModel updates.
- Added new string resources for sync options and updated existing ones for better clarity.