### PR TITLE
fix: Update upload date display in RecordingList component

### DIFF
--- a/frontend_web/audioscholar-app/src/pages/RecordingList/RecordingList.jsx
+++ b/frontend_web/audioscholar-app/src/pages/RecordingList/RecordingList.jsx
@@ -257,7 +257,15 @@ const RecordingList = () => {
                             </div>
                           </td>
                           <td className="px-6 py-5 whitespace-nowrap">
-                            <div className="text-sm text-gray-500">{new Date(recording.uploadDate).toLocaleDateString()}</div>
+                            <div className="text-sm text-gray-500">
+                              {recording.uploadTimestamp
+                                ? new Date(recording.uploadTimestamp.seconds * 1000 + recording.uploadTimestamp.nanos / 1000000).toLocaleDateString('en-US', {
+                                  month: 'long',
+                                  day: '2-digit',
+                                  year: 'numeric',
+                                })
+                                : 'N/A'}
+                            </div>
                           </td>
                           <td className="px-6 py-5 whitespace-nowrap">
                             <div className="text-sm text-gray-500">{recording.duration || 'N/A'}</div>


### PR DESCRIPTION
- Modified the upload date rendering logic in `RecordingList.jsx` to use `uploadTimestamp` for more accurate date formatting.
- Added fallback to 'N/A' when `uploadTimestamp` is not available, improving user experience by preventing display errors.